### PR TITLE
Fix no implicit any in utils.ts

### DIFF
--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"strict": true,
+		"strict": false,
 		"target": "esnext",
 		"module": "esnext",
 		"noUnusedLocals": true,

--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -9,7 +9,7 @@
 		"noUnusedLocals": true,
 
 		"noUnusedParameters": false,
-		"noImplicitAny": false,
+		"noImplicitAny": true,
 		"strictPropertyInitialization": false,
 		"strictBindCallApply": false,
 

--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -3,13 +3,13 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"strict": false,
+		"strict": true,
 		"target": "esnext",
 		"module": "esnext",
 		"noUnusedLocals": true,
 
 		"noUnusedParameters": false,
-		"noImplicitAny": true,
+		"noImplicitAny": false,
 		"strictPropertyInitialization": false,
 		"strictBindCallApply": false,
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -353,7 +353,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		};
 
 
-		addEvent(document,'mousedown',doc_mousedown);
+		addEvent(document,'mousedown', (e) => doc_mousedown(e as MouseEvent));
 		addEvent(window,'sroll', win_scroll, passive_event);
 		addEvent(window,'resize', win_scroll, passive_event);
 
@@ -869,7 +869,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		addClasses(self.wrapper,self.settings.loadingClass);
 		self.loading++;
 
-		const callback = self.loadCallback.bind(self,value);
+		const callback = self.loadCallback.bind(self);
 		self.settings.load.call(self, value, callback);
 	}
 
@@ -877,7 +877,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	 * Invoked by the user-provided option provider
 	 *
 	 */
-	loadCallback( value, options:TomOption[], optgroups:TomOption[] ):void{
+	loadCallback( options:TomOption[], optgroups:TomOption[] ):void{
 		const self = this;
 		self.loading = Math.max(self.loading - 1, 0);
 		self.lastQuery = null;

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -90,5 +90,5 @@ export type TomSettings = {
 	},
 
 	// virtual scroll plugin
-	firstUrl				: (string)=>any
+	firstUrl				: (query:string)=>any
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function escape_html(str:string):string {
  * Debounce the user provided load function
  *
  */
-export function loadDebounce(fn,delay:number){
+export function loadDebounce(fn:(self:TomSelect,value:string,callback:() => void) => void,delay:number){
 	var timeout: null|ReturnType<typeof setTimeout>;
 	return function(this:TomSelect, value:string,callback:() => void) {
 		var self = this;
@@ -67,7 +67,7 @@ export function loadDebounce(fn,delay:number){
  *
  */
 export function debounce_events( self:TomSelect, types:string[], fn:() => void ) {
-	var type;
+	var type:string;
 	var trigger = self.trigger;
 	var event_args:{ [key: string]: any } = {};
 
@@ -125,7 +125,7 @@ export function preventDefault(evt?:Event, stop:boolean=false):void{
  * Prevent default
  *
  */
-export function addEvent(target:EventTarget, type:string, callback, options?:object):void{
+export function addEvent(target:EventTarget, type:string, callback:EventListenerOrEventListenerObject, options?:object):void{
 	target.addEventListener(type,callback,options);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function escape_html(str:string):string {
  * Debounce the user provided load function
  *
  */
-export function loadDebounce(fn:(self:TomSelect,value:string,callback:() => void) => void,delay:number){
+export function loadDebounce(fn:(value:string,callback:() => any) => void,delay:number){
 	var timeout: null|ReturnType<typeof setTimeout>;
 	return function(this:TomSelect, value:string,callback:() => void) {
 		var self = this;


### PR DESCRIPTION
@oyejorge This should fix no implicit any in utils, opening a PR early since it's my first one here. This unfortunately _does_ break one test, I believe it's the `addEvent(document,'mousedown', (e) => doc_mousedown(e as MouseEvent));` change but have no idea why. Also fixed `settings.d.ts` and removed unused `value` variable in `loadCallback`.