### PR TITLE
Remove TomSelect.define from plugins

### DIFF
--- a/src/plugins/caret_position/plugin.ts
+++ b/src/plugins/caret_position/plugin.ts
@@ -17,7 +17,7 @@ import TomSelect from '../../tom-select';
 import { nodeIndex } from '../../vanilla';
 
 
-TomSelect.define('caret_position',function(this:TomSelect) {
+export default function(this:TomSelect) {
 	var self = this;
 
 	/**
@@ -49,9 +49,9 @@ TomSelect.define('caret_position',function(this:TomSelect) {
 
 		self.caretPos = new_pos;
 	});
-	
+
 	self.hook('instead','moveCaret',(direction:number) => {
-			
+
 		if( !self.isFocused ) return;
 
 		// move caret before or after selected items
@@ -66,7 +66,7 @@ TomSelect.define('caret_position',function(this:TomSelect) {
 			self.setCaret(self.caretPos + direction);
 
 		}
-		
+
 	});
 
-});
+};

--- a/src/plugins/change_listener/plugin.ts
+++ b/src/plugins/change_listener/plugin.ts
@@ -16,9 +16,8 @@
 import TomSelect from '../../tom-select';
 import { addEvent } from '../../utils';
 
-TomSelect.define('change_listener',function(this:TomSelect){
+export default function(this:TomSelect) {
 	addEvent(this.input,'change',()=>{
 		this.sync();
 	});
-
-});
+};

--- a/src/plugins/checkbox_options/plugin.ts
+++ b/src/plugins/checkbox_options/plugin.ts
@@ -12,12 +12,13 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 import { preventDefault, hash_key } from '../../utils';
 import { getDom } from '../../vanilla';
 
 
-TomSelect.define('checkbox_options',function(this:TomSelect) {
+export default function(this:TomSelect) {
 	var self = this;
 	var orig_onOptionSelect = self.onOptionSelect;
 
@@ -88,5 +89,4 @@ TomSelect.define('checkbox_options',function(this:TomSelect) {
 		UpdateCheckbox(option);
 	});
 
-
-});
+};

--- a/src/plugins/clear_button/plugin.ts
+++ b/src/plugins/clear_button/plugin.ts
@@ -17,7 +17,7 @@ import TomSelect from '../../tom-select';
 import { getDom } from '../../vanilla';
 import { CBOptions } from './types';
 
-TomSelect.define('clear_button',function(this:TomSelect, userOptions:CBOptions) {
+export default function(this:TomSelect, userOptions:CBOptions) {
 	const self = this;
 
 	const options = Object.assign({
@@ -32,15 +32,15 @@ TomSelect.define('clear_button',function(this:TomSelect, userOptions:CBOptions) 
 		var button = getDom(options.html(options));
 		button.addEventListener('click',(evt)=>{
 			self.clear();
-			
+
 			if( self.settings.mode === 'single' && self.settings.allowEmptyOption ){
 				self.addItem('');
 			}
-			
+
 			evt.preventDefault();
 			evt.stopPropagation();
 		});
 		self.control.appendChild(button);
 	});
 
-});
+};

--- a/src/plugins/drag_drop/plugin.ts
+++ b/src/plugins/drag_drop/plugin.ts
@@ -12,9 +12,10 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 
-TomSelect.define('drag_drop',function(this:TomSelect) {
+export default function(this:TomSelect) {
 	var self = this;
 	if (!$.fn.sortable) throw new Error('The "drag_drop" plugin requires jQuery UI "sortable".');
 	if (self.settings.mode !== 'multi') return;
@@ -57,4 +58,4 @@ TomSelect.define('drag_drop',function(this:TomSelect) {
 
 	});
 
-});
+};

--- a/src/plugins/dropdown_header/plugin.ts
+++ b/src/plugins/dropdown_header/plugin.ts
@@ -18,7 +18,7 @@ import { getDom } from '../../vanilla';
 import { preventDefault } from '../../utils';
 import { DHOptions } from './types';
 
-TomSelect.define('dropdown_header',function(this:TomSelect, userOptions:DHOptions) {
+export default function(this:TomSelect, userOptions:DHOptions) {
 	const self = this;
 
 	const options = Object.assign({
@@ -54,4 +54,4 @@ TomSelect.define('dropdown_header',function(this:TomSelect, userOptions:DHOption
 		self.dropdown.insertBefore(header, self.dropdown.firstChild);
 	});
 
-});
+};

--- a/src/plugins/dropdown_input/plugin.ts
+++ b/src/plugins/dropdown_input/plugin.ts
@@ -19,22 +19,22 @@ import { getDom, addClasses } from '../../vanilla';
 import { addEvent, preventDefault } from '../../utils';
 
 
-TomSelect.define('dropdown_input',function(this:TomSelect) {
+export default function(this:TomSelect) {
 	var self = this;
 
 	self.settings.shouldOpen = true; // make sure the input is shown even if there are no options to display in the dropdown
-	
+
 	self.hook('before','setup',()=>{
 		self.focus_node		= self.control;
-		
+
 		addClasses( self.control_input, 'dropdown-input');
 
 	 	const div = getDom('<div class="dropdown-input-wrap">');
 		div.append(self.control_input);
 		self.dropdown.insertBefore(div, self.dropdown.firstChild);
 	});
-	
-		
+
+
 	self.on('initialize',()=>{
 
 		// set tabIndex on control to -1, otherwise [shift+tab] will put focus right back on control_input
@@ -58,13 +58,13 @@ TomSelect.define('dropdown_input',function(this:TomSelect) {
 		self.on('blur',()=>{
 			self.focus_node.tabIndex = self.isDisabled ? -1 : self.tabIndex;
 		});
-		
-		
+
+
 		// give the control_input focus when the dropdown is open
 		self.on('dropdown_open',() =>{
 			self.control_input.focus();
 		});
-		
+
 		// prevent onBlur from closing when focus is on the control_input
 		const orig_onBlur = self.onBlur;
 		self.hook('instead','onBlur',(evt?:FocusEvent)=>{
@@ -76,11 +76,11 @@ TomSelect.define('dropdown_input',function(this:TomSelect) {
 
 		// return focus to control to allow further keyboard input
 		self.hook('before','close',() =>{
-			
+
 			if( !self.isOpen ) return;
 			self.focus_node.focus();
 		});
 
 	});
 
-});
+};

--- a/src/plugins/input_autogrow/plugin.ts
+++ b/src/plugins/input_autogrow/plugin.ts
@@ -11,11 +11,11 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 import { addEvent } from '../../utils';
 
-TomSelect.define('input_autogrow', function(this:TomSelect) {
-
+export default function(this:TomSelect) {
 	var self					= this;
 
 	self.on('initialize',()=>{
@@ -58,4 +58,4 @@ TomSelect.define('input_autogrow', function(this:TomSelect) {
 		addEvent(control,'update', resize );
 	});
 
-});
+};

--- a/src/plugins/no_active_items/plugin.ts
+++ b/src/plugins/no_active_items/plugin.ts
@@ -11,9 +11,10 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 
-TomSelect.define('no_active_items', function(this:TomSelect) {
+export default function(this:TomSelect) {
 	this.hook('instead','setActiveItem',() => {});
 	this.hook('instead','selectAll',() => {});
-});
+};

--- a/src/plugins/no_backspace_delete/plugin.ts
+++ b/src/plugins/no_backspace_delete/plugin.ts
@@ -11,12 +11,12 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 
-TomSelect.define('no_backspace_delete', function(this:TomSelect) {
+export default function(this:TomSelect) {
 	var self = this;
 	var orig_deleteSelection = self.deleteSelection;
-
 
 	this.hook('instead','deleteSelection',(evt:KeyboardEvent) => {
 
@@ -27,4 +27,4 @@ TomSelect.define('no_backspace_delete', function(this:TomSelect) {
 		return false;
 	});
 
-});
+};

--- a/src/plugins/optgroup_columns/plugin.ts
+++ b/src/plugins/optgroup_columns/plugin.ts
@@ -17,7 +17,7 @@ import TomSelect from '../../tom-select';
 import * as constants from '../../constants';
 import { parentMatch, nodeIndex } from '../../vanilla';
 
-TomSelect.define('optgroup_columns', function(this:TomSelect) {
+export default function(this:TomSelect) {
 	var self = this;
 
 	var orig_keydown = self.onKeyDown;
@@ -55,4 +55,4 @@ TomSelect.define('optgroup_columns', function(this:TomSelect) {
 
 	});
 
-});
+};

--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -12,14 +12,14 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 import { getDom } from '../../vanilla';
 import { escape_html, preventDefault, addEvent } from '../../utils';
 import { TomOption } from '../../types/index';
 import { RBOptions } from './types';
 
-
-TomSelect.define('remove_button',function(this:TomSelect, userOptions:RBOptions ){
+export default function(this:TomSelect, userOptions:RBOptions) {
 
 	const options = Object.assign({
 			label     : '&times;',
@@ -72,4 +72,4 @@ TomSelect.define('remove_button',function(this:TomSelect, userOptions:RBOptions 
 	});
 
 
-});
+};

--- a/src/plugins/restore_on_backspace/plugin.ts
+++ b/src/plugins/restore_on_backspace/plugin.ts
@@ -19,7 +19,7 @@ type TPluginOptions = {
 	text?:(option:TomOption)=>string,
 };
 
-TomSelect.define('restore_on_backspace',function(this:TomSelect, userOptions:TPluginOptions) {
+export default function(this:TomSelect, userOptions:TPluginOptions) {
 	const self = this;
 
 	const options = Object.assign({
@@ -37,4 +37,4 @@ TomSelect.define('restore_on_backspace',function(this:TomSelect, userOptions:TPl
 		}
 	});
 
-});
+};

--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -12,12 +12,12 @@
  * governing permissions and limitations under the License.
  *
  */
+
 import TomSelect from '../../tom-select';
 import { TomOption } from '../../types/index';
 import { addClasses } from '../../vanilla';
 
-
-TomSelect.define('virtual_scroll',function(this:TomSelect) {
+export default function(this:TomSelect) {
 	const self							= this;
 	const orig_canLoad					= self.canLoad;
 	const orig_clearActiveOption		= self.clearActiveOption;
@@ -172,4 +172,4 @@ TomSelect.define('virtual_scroll',function(this:TomSelect) {
 		});
 	});
 
-});
+};

--- a/src/tom-select.complete.ts
+++ b/src/tom-select.complete.ts
@@ -1,18 +1,33 @@
 import TomSelect from './tom-select';
-import './plugins/change_listener/plugin';
-import './plugins/checkbox_options/plugin';
-import './plugins/clear_button/plugin';
-import './plugins/drag_drop/plugin';
-import './plugins/dropdown_header/plugin';
-import './plugins/caret_position/plugin';
-import './plugins/dropdown_input/plugin';
-import './plugins/input_autogrow/plugin';
-import './plugins/no_backspace_delete/plugin';
-import './plugins/no_active_items/plugin';
-import './plugins/optgroup_columns/plugin';
-import './plugins/remove_button/plugin';
-import './plugins/restore_on_backspace/plugin';
-import './plugins/virtual_scroll/plugin';
 
+import change_listener from './plugins/change_listener/plugin';
+import checkbox_options from './plugins/checkbox_options/plugin';
+import clear_button from './plugins/clear_button/plugin';
+import drag_drop from './plugins/drag_drop/plugin';
+import dropdown_header from './plugins/dropdown_header/plugin';
+import caret_position from './plugins/caret_position/plugin';
+import dropdown_input from './plugins/dropdown_input/plugin';
+import input_autogrow from './plugins/input_autogrow/plugin';
+import no_backspace_delete from './plugins/no_backspace_delete/plugin';
+import no_active_items from './plugins/no_active_items/plugin';
+import optgroup_columns from './plugins/optgroup_columns/plugin';
+import remove_button from './plugins/remove_button/plugin';
+import restore_on_backspace from './plugins/restore_on_backspace/plugin';
+import virtual_scroll from './plugins/virtual_scroll/plugin';
+
+TomSelect.define('change_listener', change_listener);
+TomSelect.define('checkbox_options', checkbox_options);
+TomSelect.define('clear_button', clear_button);
+TomSelect.define('drag_drop', drag_drop);
+TomSelect.define('dropdown_header', dropdown_header);
+TomSelect.define('caret_position', caret_position);
+TomSelect.define('dropdown_input', dropdown_input);
+TomSelect.define('input_autogrow', input_autogrow);
+TomSelect.define('no_backspace_delete', no_backspace_delete);
+TomSelect.define('no_active_items', no_active_items);
+TomSelect.define('optgroup_columns', optgroup_columns);
+TomSelect.define('remove_button', remove_button);
+TomSelect.define('restore_on_backspace', restore_on_backspace);
+TomSelect.define('virtual_scroll', virtual_scroll);
 
 export default TomSelect;

--- a/src/tom-select.popular.ts
+++ b/src/tom-select.popular.ts
@@ -1,9 +1,15 @@
 import TomSelect from './tom-select';
-import './plugins/caret_position/plugin';
-import './plugins/dropdown_input/plugin';
-import './plugins/no_backspace_delete/plugin';
-import './plugins/remove_button/plugin';
-import './plugins/restore_on_backspace/plugin';
 
+import caret_position from './plugins/caret_position/plugin';
+import dropdown_input from './plugins/dropdown_input/plugin';
+import no_backspace_delete from './plugins/no_backspace_delete/plugin';
+import remove_button from './plugins/remove_button/plugin';
+import restore_on_backspace from './plugins/restore_on_backspace/plugin';
+
+TomSelect.define('caret_position', caret_position);
+TomSelect.define('dropdown_input', dropdown_input);
+TomSelect.define('no_backspace_delete', no_backspace_delete);
+TomSelect.define('remove_button', remove_button);
+TomSelect.define('restore_on_backspace', restore_on_backspace);
 
 export default TomSelect;


### PR DESCRIPTION
This moves the `TomSelect.define` call out of the plugins and into the `tom-select.popular.js` and `tom-select.complete.js`. This allows plugins to be imported individually using Webpack (or other build tools).

```js
import TomSelect from "tom-select/dist/js/tom-select.base";
TomSelect.define("remove_button", require("tom-select/dist/js/plugins/remove_button"));
TomSelect.define("clear_button", require("tom-select/dist/js/plugins/clear_button"));
```

This could be a breaking change if someone is importing plugins directly and expecting it to call `TomSelect.define`. They now need to call that themselves when importing plugins (as shown here). I doubt that is a common use case but probably worth mentioning in the change log.

Also see #222 and #68.