### PR TITLE
Dropdown not closed after creating a new item, even if closeAfterSelect is true

### DIFF
--- a/test/tests/interaction.js
+++ b/test/tests/interaction.js
@@ -58,6 +58,29 @@
 				});
 			});
 
+      it_n('should close dropdown after creating item if closeAfterSelect: true', function(done) {
+
+				var test = setup_test('AB_Multi', {closeAfterSelect: true, create: true});
+
+				// 1) focus on control
+				click(test.instance.control, function() {
+
+					// 2) type "d"
+					syn.type('d', test.instance.control_input, function() {
+
+						// 3) click on create option to create
+						var create_option = test.instance.dropdown.querySelector('.create');
+						click(create_option,function(){
+							expect(test.instance.items[0]).to.be.equal('d');
+              expect(test.instance.isOpen).to.be.equal(false);
+							done();
+						});
+
+					});
+
+				});
+			});
+
 
 			it_n('should close dropdown after selection made if closeAfterSelect: true and in single mode' , function(done) {
 

--- a/test/tests/interaction.js
+++ b/test/tests/interaction.js
@@ -72,7 +72,7 @@
 						var create_option = test.instance.dropdown.querySelector('.create');
 						click(create_option,function(){
 							expect(test.instance.items[0]).to.be.equal('d');
-              expect(test.instance.isOpen).to.be.equal(false);
+							assert.equal(test.instance.isOpen, false, 'should be closed after select');
 							done();
 						});
 


### PR DESCRIPTION
First of all, thanks for a great library! 🎉 

I think I've stumbled upon a bug though. I would assume that when `closeAfterSelect` is set to true and a user creates a new tag, the dropdown will be closed, however this is not the case.

I wrote a failing test to demonstrate the issue, but even though I've spent an hour going through the code, I'm unsure how to actually fix it. It seems that the dropdown is closed first, but then reopened immediately - perhaps due to onFocus?

Anyway, hope the test helps at least, and thanks once again!