### PR TITLE
Changed y-padding to 0 for remove button plugin

### DIFF
--- a/src/plugins/remove_button/plugin.scss
+++ b/src/plugins/remove_button/plugin.scss
@@ -11,7 +11,7 @@
 		text-decoration:	none;
 		vertical-align:		middle;
 		display:			inline-block;
-		padding:			$select-padding-item-y $select-padding-item-x;
+		padding:			0 $select-padding-item-x;
 		border-left:		1px solid $select-color-item-border;
 		border-radius:		0 2px 2px 0;
 		box-sizing:			border-box;


### PR DESCRIPTION
Replace y-padding by 0 fixes noticeable height difference for wrapper.

Related issue #270.