### PR TITLE
prevent sass deprecation warning with division

### DIFF
--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -100,7 +100,7 @@ $select-spinner-border-color:					$select-color-border !default;
 				position: absolute;
 				top: 50%;
 				right: $select-arrow-offset;
-				margin-top: round((-1 * $select-arrow-size / 2));
+				margin-top: round(-0.5 * $select-arrow-size);
 				width: 0;
 				height: 0;
 				border-style: solid;


### PR DESCRIPTION
Prevent following warning when compiling css files:

> Running "sass:build" (sass) task
> Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
> 
> Recommendation: math.div(-1 * $select-arrow-size, 2) or calc(-1 * $select-arrow-size / 2)
> 
> More info and automated migrator: https://sass-lang.com/d/slash-div
> 
>     ╷
> 103 │                 margin-top: round((-1 * $select-arrow-size / 2));
>     │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     ╵
>     src\scss\tom-select.scss 103:24        ts-caret()
>     src\scss\tom-select.default.scss 16:1  root stylesheet
> 