### PR TITLE
Add wrapperContainer option

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -41,6 +41,7 @@ export default {
 	searchConjunction: 'and',
 
 	mode: null,
+	wrapperContainer: null,
 	wrapperClass: 'ts-wrapper',
 	controlClass: 'ts-control',
 	dropdownClass: 'ts-dropdown',

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -65,7 +65,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	public isDisabled				: boolean = false;
 	public isRequired				: boolean;
 	public isInvalid				: boolean = false; // @deprecated 1.8
-	public isValid					: boolean = true; 
+	public isValid					: boolean = true;
 	public isLocked					: boolean = false;
 	public isFocused				: boolean = false;
 	public isInputHidden			: boolean = false;
@@ -151,14 +151,14 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		this.initializePlugins(settings.plugins);
 		this.setupCallbacks();
 		this.setupTemplates();
-		
-		
+
+
 		// Create all elements
 		const wrapper			= getDom('<div>');
 		const control			= getDom('<div>');
 		const dropdown			= this._render('dropdown');
 		const dropdown_content	= getDom(`<div role="listbox" tabindex="-1">`);
-			
+
 		const classes			= this.input.getAttribute('class') || '';
 		const inputMode			= settings.mode;
 
@@ -166,14 +166,14 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 
 		addClasses( wrapper, settings.wrapperClass, classes, inputMode);
-		
+
 
 		addClasses(control,settings.controlClass);
 		append( wrapper, control );
 
 
 		addClasses(dropdown, settings.dropdownClass, inputMode);
-		if( settings.copyClassesToDropdown ){ 
+		if( settings.copyClassesToDropdown ){
 			addClasses( dropdown, classes);
 		}
 
@@ -195,12 +195,12 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 					setAttr(control_input,{[attr]:input.getAttribute(attr)});
 				}
 			});
-			
+
 			control_input.tabIndex = -1;
 			control.appendChild( control_input );
 			this.focus_node		= control_input;
-		
-		// dom element	
+
+		// dom element
 		}else if( settings.controlInput ){
 			control_input		= getDom( settings.controlInput ) as HTMLInputElement;
 			this.focus_node		= control_input;
@@ -209,7 +209,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			control_input		= getDom('<input/>') as HTMLInputElement;
 			this.focus_node		= control;
 		}
-		
+
 		this.wrapper			= wrapper;
 		this.dropdown			= dropdown;
 		this.dropdown_content	= dropdown_content;
@@ -222,7 +222,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	/**
 	 * set up event bindings.
 	 *
-	 */	
+	 */
 	setup(){
 
 		const self = this;
@@ -288,8 +288,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		}
 
 		self.control_input.type	= input.type;
-		
-		
+
+
 		// clicking on an option should select it
 		addEvent(dropdown,'click',(evt) => {
 			const option = parentMatch(evt.target as HTMLElement, '[data-selectable]');
@@ -316,14 +316,14 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			preventDefault(evt,true);
 		});
 
-		
+
 		// keydown on focus_node for arrow_down/arrow_up
 		addEvent(focus_node,'keydown',		(e) => self.onKeyDown(e as KeyboardEvent) );
-		
+
 		// keypress and input/keyup
 		addEvent(control_input,'keypress',	(e) => self.onKeyPress(e as KeyboardEvent) );
 		addEvent(control_input,'input',		(e) => self.onInput(e as KeyboardEvent) );
-		
+
 		addEvent(focus_node,'resize',		() => self.positionDropdown(), passive_event);
 		addEvent(focus_node,'blur', 		(e) => self.onBlur(e as FocusEvent) );
 		addEvent(focus_node,'focus',		(e) => self.onFocus(e as MouseEvent) );
@@ -342,8 +342,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 				self.inputState();
 				return;
 			}
-				
-			
+
+
 			// retain focus by preventing native handling. if the
 			// event target is the input it should not be modified.
 			// otherwise, text selection within the input won't work.
@@ -355,7 +355,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			}else{
 				preventDefault(evt,true);
 			}
-						
+
 		};
 
 		var win_scroll = () => {
@@ -385,7 +385,11 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 
 		input.tabIndex = -1;
-		input.insertAdjacentElement('afterend', self.wrapper);
+		if (! settings.wrapperContainer) {
+			input.insertAdjacentElement('afterend', self.wrapper);
+		} else {
+			document.querySelector(settings.wrapperContainer).appendChild(self.wrapper);
+		}
 
 		self.sync(false);
 		settings.items = [];
@@ -582,7 +586,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		if( self.isInputHidden || self.isLocked ){
 			preventDefault(e);
 			return;
-		}		
+		}
 
 		// If a regex or string is included, this will split the pasted
 		// input and create Items for each separate value
@@ -846,7 +850,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			}
 		}
 	}
-	
+
 	/**
 	 * Return true if the given option can be selected
 	 *
@@ -935,7 +939,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		self.trigger('load', options, optgroups);
 	}
-	
+
 	preload():void{
 		var classList = this.wrapper.classList;
 		if( classList.contains('preloaded') ) return;
@@ -1173,7 +1177,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		const activeItems = self.controlChildren();
 
 		if( !activeItems.length ) return;
-		
+
 		self.hideInput();
 		self.close();
 
@@ -1181,7 +1185,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		iterate( activeItems, (item) => {
 			self.setActiveItemClass(item);
 		});
-		
+
 	}
 
 	/**
@@ -1192,18 +1196,18 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		var self = this;
 
 		if( !self.control.contains(self.control_input) ) return;
-					
+
 		setAttr(self.control_input,{placeholder:self.settings.placeholder});
 
 		if( self.activeItems.length > 0 || (!self.isFocused && self.settings.hidePlaceholder && self.items.length > 0) ){
 			self.setTextboxValue();
 			self.isInputHidden = true;
-			
+
 		}else{
-						
+
 			if( self.settings.hidePlaceholder && self.items.length > 0 ){
 				setAttr(self.control_input,{placeholder:''});
-			}			
+			}
 			self.isInputHidden = false;
 		}
 
@@ -1242,13 +1246,13 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		if (self.isDisabled) return;
 
 		self.ignoreFocus = true;
-		
+
 		if( self.control_input.offsetWidth ){
 			self.control_input.focus();
 		}else{
 			self.focus_node.focus();
 		}
-		
+
 		setTimeout(() => {
 			self.ignoreFocus = false;
 			self.onFocus();
@@ -1377,8 +1381,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			let opt_value		= results.items[i].id;
 			let option			= self.options[opt_value];
 			let option_el		= self.getOption(opt_value,true) as HTMLElement;
-			
-			
+
+
 			// toggle 'selected' class
 			if( !self.settings.hideSelected ){
 				option_el.classList.toggle('selected', self.items.includes(opt_value) );
@@ -1413,7 +1417,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 						}
 					}else{
 						active_option = option_el;
-					}	
+					}
 				}
 
 				groups[optgroup].appendChild(option_el);
@@ -1470,12 +1474,12 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			}
 			return content;
 		};
-		
+
 
 		// add loading message
 		if( self.loading ){
 			add_template('loading');
-			
+
 		// invalid query
 		}else if( !self.settings.shouldLoad.call(self,query) ){
 			add_template('not_loading');
@@ -1580,7 +1584,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		return key;
 	}
-	
+
 	/**
 	 * Add multiple options
 	 *
@@ -1661,7 +1665,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		const value_old		= hash_key(value);
 		const value_new		= hash_key(data[self.settings.valueField]);
-		
+
 		// sanity checks
 		if( value_old === null ) return;
 		if( !self.options.hasOwnProperty(value_old) ) return;
@@ -1761,16 +1765,16 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		if( hashed !== null && this.options.hasOwnProperty(hashed) ){
 			const option = this.options[hashed];
-						
+
 			if( option.$div ){
 				return option.$div;
 			}
-			
+
 			if( create ){
 				return this._render('option', option);
 			}
 		}
-		
+
 		return null;
 	}
 
@@ -2041,8 +2045,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		const isLocked	= self.isLocked;
 
 		self.wrapper.classList.toggle('rtl',self.rtl);
-		
-		
+
+
 		const wrap_classList = self.wrapper.classList;
 
 		wrap_classList.toggle('focus', self.isFocused)
@@ -2096,7 +2100,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	updateOriginalInput( opts:TomArgObject = {} ){
 		const self = this;
 		var option, label;
-		
+
 		const empty_option = self.input.querySelector('option[value=""]') as HTMLOptionElement;
 
 		if( self.is_select_tag ){
@@ -2111,11 +2115,11 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 				}
 
 				// don't move empty option from top of list
-				// fixes bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1725293				
+				// fixes bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1725293
 				if( option_el != empty_option ){
 					self.input.append(option_el);
 				}
-				
+
 				selected.push(option_el);
 
 				// marking empty option as selected can break validation
@@ -2135,12 +2139,12 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 			// nothing selected?
 			if( self.items.length == 0 && self.settings.mode == 'single' ){
-							
+
 				AddSelected(empty_option, "", "");
 
 			// order selected <option> tags for values in self.items
 			}else{
-					
+
 				self.items.forEach((value)=>{
 					option			= self.options[value];
 					label			= option[self.settings.labelField] || '';
@@ -2263,7 +2267,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	 *
 	 */
 	insertAtCaret(el:HTMLElement) {
-		const self		= this;		
+		const self		= this;
 		const caret		= self.caretPos;
 		const target	= self.control;
 
@@ -2377,7 +2381,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			self.moveCaret(direction);
 		}
 	}
-	
+
 	moveCaret(direction:number){}
 
 	/**
@@ -2508,7 +2512,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	_render( templateName:TomTemplateNames, data?:any ):HTMLElement{
 		var value = '', id, html;
 		const self = this;
-		
+
 		if( templateName === 'option' || templateName == 'item' ){
 			value	= get_hash(data[self.settings.valueField]);
 		}
@@ -2579,7 +2583,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 				delete option.$div;
 			}
 		});
-		
+
 	}
 
 	/**

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -53,6 +53,7 @@ export type TomSettings = {
 	nesting					: boolean,
 
 	mode					: string,
+	wrapperContainer		: string,
 	wrapperClass			: string,
 	controlClass			: string,
 	dropdownClass			: string,


### PR DESCRIPTION
This PR adds an wrapperContainer option. 

With this options you can specify via an query selector where the select markup should be rendered.

**Usage**
```html
<select id="select"></select>
<div id="test-wrapper"></div>
```
```js
new TomSelect('#select',{
	wrapperContainer: '#test-wrapper',
	options: [
		{id: 1, title: 'DIY', url: 'https://diy.org'},
		{id: 2, title: 'Google', url: 'http://google.com'},
		{id: 3, title: 'Yahoo', url: 'http://yahoo.com'},
	]
```

The select and the dropdown markup will now be a child from `div#test-wrapper`.

**But why do you need this?**

**Good that you ask!**

We want to implement the tom-select in our backend-rendered application that updated the Frontend Markup with DOM-Diffing.

The Problem with the current implementation is, that the auto-generated wrapper will be attached after the select and when the diff occures it will be removed.
If we could specify an seperate DOM element we could tell the "Differ" to ignore that element and everything would work.


_Additionally, every empty line with spaces and trailing line spaces are removed... Sry for that, the IDE has done this automatically. I tried to commit my changes without the style fixes but it reapplied it again on save 🙈_

_And Additionally for the addition, I implemented no tests for that... I have never worked on a JS/TS project and don't know how and where to add this... but if you tell me where and how I will add them too 😀_