### PR TITLE
fix typo

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -371,7 +371,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		this._destroy = () => {
 			document.removeEventListener('mousedown',doc_mousedown);
-			window.removeEventListener('sroll',win_scroll);
+			window.removeEventListener('scroll',win_scroll);
 			window.removeEventListener('resize',win_scroll);
 			if( label ) label.removeEventListener('click',label_click);
 		};


### PR DESCRIPTION
I was looking into where to hook into coping with scrollable elements not triggering win_scroll and found a typo.