### PR TITLE
Add units to `0` values to fix invalid CSS 

### DIFF
--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -54,7 +54,7 @@ $select-border:									$select-border-width solid $select-color-border !default
 $select-dropdown-border:						1px solid $select-color-dropdown-border !default;
 $select-border-radius:							3px !default;
 
-$select-width-item-border:						0 !default;
+$select-width-item-border:						0px !default;
 $select-max-height-dropdown:					200px !default;
 
 $select-padding-x:								8px !default;
@@ -70,8 +70,8 @@ $select-arrow-size:								5px !default;
 $select-arrow-color:								#808080 !default;
 $select-arrow-offset:							15px !default;
 
-$select-caret-margin:							0 4px !default;
-$select-caret-margin-rtl:						0 4px 0 -2px !default;
+$select-caret-margin:							0px 4px !default;
+$select-caret-margin-rtl:						0px 4px 0px -2px !default;
 
 $select-spinner-size:							30px !default;
 $select-spinner-border-size:					5px !default;


### PR DESCRIPTION
This adds units to `0` values which was producing invalid CSS. The
output being produced upon Sass compilation here in this repo—and as
it’s found in `tom-select.css`—was:

```css
padding: calc( 8px - 2px - 0) 8px calc( 8px - 2px - 3px - 0);
```

The issue I stumbled upon is when I then imported that via Sass (Dart
Sass v1.52.3) into my project, an error occured:

```
Error: 6px and 0 are incompatible.
```

At first I thought this must be a bug in Sass. However, after searching
the Dart Sass GitHub Isssues, I came across an already filed [issue
describing exactly what I was seeing][gh-issue]. A contributor to Sass
responded to and closed the issue stating that a unitless 0 is not
supported in `calc`. They also linked to the [CSS Spec, which
states][spec]:

> Note: Because <number-token>s are always interpreted as <number>s or
> <integer>s, "unitless 0" <length>s aren’t supported in calc(). That
> is, width: calc(0 + 5px); is invalid, even though both width: 0; and
> width: 5px; are valid.

Back to Tom Select…

We’re using `calc` here so that downstream consumers have the ability to
override these Sass variables with different values and different units.
`calc` is capable of calculating mixed units. So the solution here is to
add units to `0` values found in our default Sass variables.

[gh-issue]: sass/dart-sass#1544
[spec]: https://www.w3.org/TR/css-values-3/#calc-type-checking