### PR TITLE
Fix Bootstrap 5 single selected item right margin

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -205,6 +205,16 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		}
 	}
 
+	&.single {
+        &.has-items.input-hidden {
+            .#{$select-ns}-control {
+                .item {
+                    padding-right: $select-padding-item-x * 8;
+                }
+            }
+        }
+    }
+
 
 	&.multi {
 		&.has-items .#{$select-ns}-control {


### PR DESCRIPTION
When the selector is in single mode and has no space, the selected item is displayed on the select arrow.

![Capture d’écran 2022-06-13 à 10 15 44](https://user-images.githubusercontent.com/5328934/173311131-a398f9c4-418e-4ef2-ab21-149542fb3768.png)

This fix allows this selected option to be displayed correctly with a padding right when the dropdown is not activated.

![Capture d’écran 2022-06-13 à 10 15 06](https://user-images.githubusercontent.com/5328934/173311147-8d64c23e-a39e-4d4d-a75c-e0121d48261b.png)