### PR TITLE
Fix optgroup active

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1446,7 +1446,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 				// make sure we keep the activeOption in the same group
 				if( !active_option && active_value == opt_value ){
 					if( active_group ){
-						if( active_group.dataset.group === optgroup ){
+						if( active_group.dataset.group === optgroup.toString() ){
 							active_option = option_el;
 						}
 					}else{


### PR DESCRIPTION
When the select is with optgroups, the activeElement is always set to the first one. The reason is just a mistake in the condition. Tested via a plugin and it works properly with this fix.  

You can reproduce the bug by go to the simple example (https://tom-select.js.org/examples/optgroups/) and scroll down in the dropdown and click on the last option. You will be redirect to the active element, the first one instead of the active one.