### PR TITLE
Correct clear button plugin's Bootstrap5 position

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -282,3 +282,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		border-bottom-right-radius: 0;
 	}
 }
+
+.#{$select-ns}-wrapper .plugin-clear_button.single .clear-button {
+	right: .75em;
+}

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -283,6 +283,6 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	}
 }
 
-.#{$select-ns}-wrapper .plugin-clear_button.single .clear-button {
-	right: .75em;
+.#{$select-ns}-wrapper.plugin-clear_button.single .clear-button {
+	right: $select-padding-dropdown-item-x;
 }


### PR DESCRIPTION
# Before

<img width="202" alt="image" src="https://user-images.githubusercontent.com/14306/188598540-d18cbfc7-a437-4cfe-86bf-9af874c91912.png">

The default CSS "right" attribute for a single clear button is a `calc(2.75rem - 5px)` which makes the clear button stay too far from the right border.

# After

<img width="208" alt="image" src="https://user-images.githubusercontent.com/14306/188598478-57f49b7b-4e18-4d90-a7be-619a860891e0.png">

Using a .75em right position mimic other Bootstrap 5 alignments values.