### PR TITLE
Fix deprecation warning in Tom Select bootstrap 5

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -28,7 +28,7 @@ $select-color-optgroup: $dropdown-bg !default;
 $select-color-optgroup-text: $dropdown-header-color !default;
 $select-color-optgroup-border: $dropdown-divider-bg !default;
 $select-color-dropdown: $dropdown-bg !default;
-$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 0.8) !default;
+$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 80%) !default;
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;


### PR DESCRIPTION
Deprecation Warning: $weight: Passing a number without unit % (0.8) is deprecated. To preserve current behavior: $weight * 1%
More info: https://sass-lang.com/d/function-units

PS: I am not sure if it should be 0.8% instead of 80%? But that would be weird percentage.