### PR TITLE
Set units for 0 values

### DIFF
--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -78,8 +78,8 @@ $select-spinner-border-size:					5px !default;
 $select-spinner-border-color:					$select-color-border !default;
 
 :root{
-	--ts-pr-clear-button:						0;
-	--ts-pr-caret:								0;
+	--ts-pr-clear-button:						0rem;
+	--ts-pr-caret:								0rem;
 	--ts-pr-min:								.75rem;
 }
 


### PR DESCRIPTION
The value `0` should have a default unit, otherwise CSS calculations will not work, CSS can't handle it.

`calc(0 + 1rem)` => error
`calc(0rem + 1rem)` => `1rem`

This will actually fix a bug in the examples;
https://tom-select.js.org/examples/styling/

![image](https://user-images.githubusercontent.com/1838187/205511888-56e1a601-6012-4408-8438-292245d11487.png)

![image](https://user-images.githubusercontent.com/1838187/205511904-286d8452-e353-47fc-9505-bbde6da338c4.png)
