### PR TITLE
Use SifterTypes from dist folder instead of lib

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -2,7 +2,7 @@
 import { TomCreateFilter, TomCreate, TomLoadCallback, TomTemplates, TomOption } from './index';
 
 import { TPluginItem, TPluginHash } from '../contrib/microplugin';
-import * as SifterTypes from '@orchidjs/sifter/lib/types';
+import * as SifterTypes from '@orchidjs/sifter/dist/types/types';
 
 
 


### PR DESCRIPTION
This change fixes the problem that generated .d.ts files containing references to .ts files from @orchidjs/sifter library. Import from lib folder can be problematic for some TypeScript compilation configurations because Sifter types are not determined as library files in that case.