### PR TITLE
Fix onItemRemove method signature

### DIFF
--- a/doc_src/pages/docs/index.md
+++ b/doc_src/pages/docs/index.md
@@ -460,7 +460,7 @@ new TomSelect('#select',{
 		<td>Invoked when an item is selected.</td>
 	</tr>
 	<tr>
-		<td><code>onItemRemove(value)</code></td>
+		<td><code>onItemRemove(value, $item)</code></td>
 		<td>Invoked when an item is deselected.</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
`onItemRemove` receives both the value and the item reference

<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->
