### PR TITLE
fix: bootstrap5 input-group button / .input-group-text wrapping

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -173,6 +173,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 .#{$select-ns}-wrapper {
 	min-height: $input-height;
 	display:flex;
+	width: 1%;
 
 	.input-group-sm > &,
 	&.form-select-sm,


### PR DESCRIPTION
bootstrap5 styles are missing width when using input-group classes

example

https://jsfiddle.net/mArtinko5MB/m5ob67u8/2/

buttons or any input group element is wrapped
