### PR TITLE
(BSR) doc(README): add information about readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Tom Select was forked from [selectize.js](https://tom-select.js.org/docs/selecti
 - **Extensible**<br> [Plugin API](https://tom-select.js.org/docs/plugins/) for developing custom features (uses [microplugin](https://github.com/brianreavis/microplugin.js)).
 - **Accessible**, **Touch Support**, **Clean API**, ...
 
+> It is important to mention when choosing this library that `readonly` attribute is not yet implemented.
+
 ## Usage
 
 ```html


### PR DESCRIPTION
In order to help team, I added a note to warn that `readonly` attribute is not yet supported.

This is related to :  

- https://github.com/orchidjs/tom-select/issues/537
- https://github.com/orchidjs/tom-select/issues/587

<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->
