### PR TITLE
Add Stylelint and a reasonable configuration, and bring SASS/SCSS up-to-spec

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,9 @@
+{
+    "extends": ["stylelint-config-standard-scss"],
+    "rules": {
+      "scss/at-import-partial-extension": null,
+      "scss/dollar-variable-colon-space-after": null,
+      "scss/dollar-variable-empty-line-before": null,
+      "no-invalid-position-at-import-rule": null
+    }
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "rollup-plugin-insert": "^1.3.2",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.9",
+    "stylelint": "^15.6.2",
+    "stylelint-config-standard": "^33.0.0",
+    "stylelint-config-standard-scss": "^9.0.0",
     "syn": "^0.15.0",
     "tslib": "^2.4.0",
     "typescript": "^4.8.3"
@@ -95,6 +98,7 @@
     "test": "karma start",
     "test:one": "karma start --test_one",
     "test:typescript": "tsc -p .config --noemit",
+    "sass-lint": "stylelint -q src/scss",
     "start": "grunt serve",
     "pretest": "grunt build",
     "prepare": "husky install"

--- a/src/scss/-tom-select.bootstrap4.scss
+++ b/src/scss/-tom-select.bootstrap4.scss
@@ -1,5 +1,3 @@
-
-
 @import "../../node_modules/bootstrap/scss/functions";
 @import "../../node_modules/bootstrap/scss/variables";
 @import "../../node_modules/bootstrap/scss/mixins";

--- a/src/scss/_dropdown.scss
+++ b/src/scss/_dropdown.scss
@@ -6,19 +6,19 @@
 	left: 0;
 	width: 100%;
 	z-index: 10;
-
 	border: $select-dropdown-border;
 	background: $select-color-dropdown;
-	margin: 0.25rem 0 0 0;
+	margin: 0.25rem 0 0;
 	border-top: 0 none;
 	box-sizing: border-box;
-	box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+	box-shadow: 0 1px 3px rgba(0 0 0 / 10%);
 	border-radius: 0 0 $select-border-radius $select-border-radius;
 
 
 	[data-selectable] {
 		cursor: pointer;
 		overflow: hidden;
+
 		.highlight {
 			background: $select-color-highlight;
 			border-radius: 1px;
@@ -55,6 +55,7 @@
 	.active {
 		background-color: $select-color-dropdown-item-active;
 		color: $select-color-dropdown-item-active-text;
+
 		&.create {
 			color: $select-color-dropdown-item-create-active-text;
 		}
@@ -71,7 +72,7 @@
 		margin: $select-padding-dropdown-item-y $select-padding-dropdown-item-x;
 
 
-		&:after {
+		&::after {
 			content: " ";
 			display: block;
 			width: $select-spinner-size * .8;
@@ -82,10 +83,12 @@
 			border-color: $select-spinner-border-color transparent $select-spinner-border-color transparent;
 			animation: lds-dual-ring 1.2s linear infinite;
 		}
+
 		@keyframes lds-dual-ring {
 			0% {
 				transform: rotate(0deg);
 			}
+
 			100% {
 				transform: rotate(360deg);
 			}
@@ -97,6 +100,5 @@
 	overflow-y: auto;
 	overflow-x: hidden;
 	max-height: $select-max-height-dropdown;
-	overflow-scrolling: touch;
 	scroll-behavior: smooth;
 }

--- a/src/scss/_items.scss
+++ b/src/scss/_items.scss
@@ -1,7 +1,6 @@
 
 
 .#{$select-ns}-control {
-
 	border: $select-border;
 	padding: $select-padding-y $select-padding-x;
 	width: 100%;
@@ -18,6 +17,7 @@
 		$padding-x: $select-padding-x;
 		$padding-top: calc( #{$select-padding-y} - #{$select-padding-item-y} - #{$select-width-item-border});
 		$padding-bottom: calc( #{$select-padding-y} - #{$select-padding-item-y} - #{$select-margin-item-y} - #{$select-width-item-border});
+
 		padding: $padding-top $padding-x $padding-bottom;
 	}
 
@@ -56,9 +56,9 @@
 
 	.#{$select-ns}-wrapper.multi.disabled & > div {
 		&, &.active {
-			color: lighten(desaturate($select-color-item-text, 100%), $select-lighten-disabled-item-text);
-			background: lighten(desaturate($select-color-item, 100%), $select-lighten-disabled-item);
-			border: $select-width-item-border solid lighten(desaturate($select-color-item-border, 100%), $select-lighten-disabled-item-border);
+			color: color.adjust(color.adjust($select-color-item-text, $saturation: -100%), $lightness: $select-lighten-disabled-item-text);
+			background: color.adjust(color.adjust($select-color-item, $saturation: -100%), $lightness: $select-lighten-disabled-item);
+			border: $select-width-item-border solid color.adjust(color.adjust($select-color-item-border, $saturation: -100%), $lightness: $select-lighten-disabled-item-border);
 		}
 	}
 

--- a/src/scss/tom-select.bootstrap4.scss
+++ b/src/scss/tom-select.bootstrap4.scss
@@ -2,33 +2,33 @@
  * Tom Select bootstrap 4
  */
 
-//Import Boostrap 4 functions and variables
+// Import Boostrap 4 functions and variables
 
-$state-valid: map-get($form-validation-states,'valid') !default;
-$state-invalid: map-get($form-validation-states,'invalid') !default;
+$state-valid: map.get($form-validation-states,'valid') !default;
+$state-invalid: map.get($form-validation-states,'invalid') !default;
 
 $enable-shadows: true !default;
 $select-font-family: inherit !default;
 $select-font-size: inherit !default;
-$select-line-height: $input-btn-line-height !default; //formerly line-height-computed
+$select-line-height: $input-btn-line-height !default; // formerly line-height-computed
 
-$select-color-text: gray("800") !default; //$gray-800
-$select-color-highlight: rgba(255,237,40,0.4) !default;
+$select-color-text: gray("800") !default; // $gray-800
+$select-color-highlight: rgb(255 237 40 / 40%) !default;
 $select-color-input: $input-bg !default;
 $select-color-input-full: $input-bg !default;
-$select-color-input-error: map-get($state-invalid,'color') !default;
-$select-color-input-error-focus: darken($select-color-input-error, 10%) !default;
+$select-color-input-error: map.get($state-invalid,'color') !default;
+$select-color-input-error-focus: color.adjust($select-color-input-error, $lightness: -10%) !default;
 $select-color-disabled: $input-disabled-bg !default;
 $select-color-item: #efefef !default;
 $select-color-item-border: $border-color !default;
 $select-color-item-active: $component-active-bg !default;
 $select-color-item-active-text: #fff !default;
-$select-color-item-active-border: rgba(0,0,0,0) !default;
+$select-color-item-active-border: rgb(0 0 0 / 0%) !default;
 $select-color-optgroup: $dropdown-bg !default;
 $select-color-optgroup-text: $dropdown-header-color !default;
 $select-color-optgroup-border: $dropdown-divider-bg !default;
 $select-color-dropdown: $dropdown-bg !default;
-$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 0.8) !default;
+$select-color-dropdown-border-top: color.mix($input-border-color, $input-bg, 80%) !default;
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;
@@ -37,7 +37,7 @@ $select-opacity-disabled: 0.5 !default;
 $select-border: 1px solid $input-border-color !default;
 $select-border-radius: $input-border-radius !default;
 
-$select-width-item-border: 0px !default;
+$select-width-item-border: 0 !default;
 $select-padding-x: $input-btn-padding-x !default;
 $select-padding-y: $input-btn-padding-y !default;
 $select-padding-dropdown-item-x: $input-btn-padding-x !default;
@@ -53,7 +53,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 
 @import "tom-select";
-@include ts-caret();
+@include ts-caret;
 
 .#{$select-ns}-wrapper.form-control,
 .#{$select-ns}-wrapper.form-select{
@@ -66,9 +66,9 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	padding: 0;
 	z-index: $zindex-dropdown;
 	background: $select-color-dropdown;
-	border: 1px solid $dropdown-border-color; //$dropdown-fallback-border
+	border: 1px solid $dropdown-border-color; // $dropdown-fallback-border
 	border-radius: $border-radius;
-	box-shadow: 0 6px 12px rgba(0,0,0,.175);
+	box-shadow: 0 6px 12px rgb(0 0 0 / 17.5%);
 }
 
 .#{$select-ns}-dropdown {
@@ -76,18 +76,24 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		font-size: $font-size-sm;
 		line-height: $line-height-base;
 	}
-	.optgroup:first-child:before {
-		display: none;
-	}
-	.optgroup:before {
-		content: ' ';
-		display: block;
-		height: 0;
-		margin: $dropdown-divider-margin-y 0;
-		overflow: hidden;
-		border-top: 1px solid $dropdown-divider-bg;
-		margin-left: $select-padding-dropdown-item-x * -1;
-		margin-right: $select-padding-dropdown-item-x * -1;
+
+	.optgroup {
+		&:first-child {
+			&::before {
+				display: none;
+			}
+		}
+
+		&::before {
+			content: ' ';
+			display: block;
+			height: 0;
+			margin: $dropdown-divider-margin-y 0;
+			overflow: hidden;
+			border-top: 1px solid $dropdown-divider-bg;
+			margin-left: $select-padding-dropdown-item-x * -1;
+			margin-right: $select-padding-dropdown-item-x * -1;
+		}
 	}
 
 	.create {
@@ -100,15 +106,17 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 }
 
 .#{$select-ns}-control {
-	min-height: $input-height;
 	@include box-shadow($input-box-shadow);
 	@include transition($input-transition);
+
+	min-height: $input-height;
 	display:flex;
 	align-items: center;
 
 	.focus & {
 		border-color: $input-focus-border-color;
 		outline: 0;
+
 		@if $enable-shadows {
 			box-shadow: $input-box-shadow, $input-focus-box-shadow;
 		} @else {
@@ -128,8 +136,8 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 }
 
 .is-valid .#{$select-ns}-control{
-	$_color: map-get($state-valid,'color');
-	//$_icon: map-get($state-valid,'icon');
+	// $_icon: map.get($state-valid, 'icon');
+	$_color: map.get($state-valid, 'color');  /* stylelint-disable-line scss/dollar-variable-pattern */
 
 	border-color: $_color;
 
@@ -140,16 +148,14 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 }
 
 .#{$select-ns}-wrapper {
-
 	.input-group-sm > &,
 	&.form-control-sm{
-
-		.#{$select-ns}-control{
-			min-height: $input-height-sm;
-			padding: 0 .75rem;
-			//padding: $input-padding-y-sm $input-padding-x-sm;
+		.#{$select-ns}-control {
 			@include border-radius($input-border-radius-sm);
 			@include font-size($input-font-size-sm);
+
+			min-height: $input-height-sm;
+			padding: 0 .75rem; // padding: $input-padding-y-sm $input-padding-x-sm;
 		}
 
 		&.has-items .#{$select-ns}-control{
@@ -166,7 +172,8 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 			// padding-top = ($input-height-sm - border-width - item-height) / 2;
 			// item-height = ($select-line-height * $input-font-size-sm) + ($select-padding-item-y * 2)
 			$border-and-padding: add($input-border-width,$select-padding-item-y) * 2;
-			$ts-select-padding-sm: calc( (#{$input-height-sm} - (#{$select-line-height} * #{$input-font-size-sm}) - #{$border-and-padding})/2);
+			$ts-select-padding-sm: calc((#{$input-height-sm} - (#{$select-line-height} * #{$input-font-size-sm}) - #{$border-and-padding}) / 2);
+
 			padding-top: $ts-select-padding-sm !important;
 		}
 	}
@@ -174,9 +181,11 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 	&.multi {
 		&.has-items .#{$select-ns}-control {
-			padding-left: calc(#{$select-padding-x} - #{$select-padding-item-x});
 			--ts-pr-min: calc(#{$select-padding-x} - #{$select-padding-item-x});
+
+			padding-left: calc(#{$select-padding-x} - #{$select-padding-item-x});
 		}
+
 		.#{$select-ns}-control > div {
 			border-radius: calc(#{$select-border-radius} - 1px);
 		}
@@ -185,9 +194,10 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	.input-group-lg > & >,
 	&.form-control-lg{
 	.#{$select-ns}-control{
-			min-height: $input-height-lg;
 			@include border-radius($input-border-radius-lg);
 			@include font-size($input-font-size-lg);
+
+			min-height: $input-height-lg;
 		}
 	}
 }
@@ -197,12 +207,12 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	height: auto;
 	border: none;
 	background: none;
-	//box-shadow: none;
 	border-radius: 0;
+
+	// box-shadow: none;
 }
 
 .input-group{
-
 	& > .#{$select-ns}-wrapper{
 		flex-grow: 1;
 	}

--- a/src/scss/tom-select.bootstrap4.scss
+++ b/src/scss/tom-select.bootstrap4.scss
@@ -1,6 +1,8 @@
 /**
  * Tom Select bootstrap 4
  */
+@use "sass:color";
+@use "sass:map";
 
 // Import Boostrap 4 functions and variables
 

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -2,18 +2,18 @@
  * Tom Select bootstrap 5
  */
 
-//Import Boostrap 5 functions and variables
-$state-valid: map-get($form-validation-states,'valid') !default;
-$state-invalid: map-get($form-validation-states,'invalid') !default;
+// Import Boostrap 5 functions and variables
+$state-valid: map.get($form-validation-states,'valid') !default;
+$state-invalid: map.get($form-validation-states,'invalid') !default;
 
 
 $enable-shadows: true !default;
 $select-font-family: inherit !default;
 $select-font-size: inherit !default;
-$select-line-height: $input-btn-line-height !default; //formerly line-height-computed
+$select-line-height: $input-btn-line-height !default; // formerly line-height-computed
 
 $select-color-text: $gray-800 !default;
-$select-color-highlight: rgba(255,237,40,0.4) !default;
+$select-color-highlight: rgb(255 237 40 / 40%) !default;
 $select-color-input: $input-bg !default;
 $select-color-input-full: $input-bg !default;
 
@@ -23,12 +23,12 @@ $select-color-item: #efefef !default;
 $select-color-item-border: $border-color !default;
 $select-color-item-active: $component-active-bg !default;
 $select-color-item-active-text: #fff !default;
-$select-color-item-active-border: rgba(0,0,0,0) !default;
+$select-color-item-active-border: rgb(0 0 0 / 0%) !default;
 $select-color-optgroup: $dropdown-bg !default;
 $select-color-optgroup-text: $dropdown-header-color !default;
 $select-color-optgroup-border: $dropdown-divider-bg !default;
 $select-color-dropdown: $dropdown-bg !default;
-$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 80%) !default;
+$select-color-dropdown-border-top: color.mix($input-border-color, $input-bg, 80%) !default;
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;
@@ -37,7 +37,7 @@ $select-opacity-disabled: 0.5 !default;
 $select-border: 1px solid $input-border-color !default;
 $select-border-radius: $input-border-radius !default;
 
-$select-width-item-border: 0px !default;
+$select-width-item-border: 0 !default;
 $select-padding-x: $input-padding-x !default;
 $select-padding-y: $input-padding-y !default;
 $select-padding-dropdown-item-x: $input-btn-padding-x !default;
@@ -57,14 +57,14 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 @mixin ts-form-validation-state-selector($state) {
 
-	$state-map: map-get($form-validation-states,$state);
+	$state-map: map.get($form-validation-states,$state);
 
 	.#{$select-ns}-wrapper.is-#{$state},
 	.was-validated .#{$state},
 	.was-validated :#{$state} + .#{$select-ns}-wrapper{
 
-		$color: map-get($state-map,'color');
-		$icon: map-get($state-map,'icon');
+		$color: map.get($state-map,'color');
+		$icon: map.get($state-map,'icon');
 
 		border-color: $color;
 
@@ -90,15 +90,6 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	}
 }
 
-
-.#{$select-ns}-wrapper.form-control,
-.#{$select-ns}-wrapper.form-select{
-	padding:0 !important;
-	height: auto;
-	box-shadow: none;
-	display: flex;
-}
-
 .#{$select-ns}-dropdown,
 .#{$select-ns}-dropdown.form-control,
 .#{$select-ns}-dropdown.form-select{
@@ -106,9 +97,9 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	padding: 0;
 	z-index: $zindex-dropdown;
 	background: $select-color-dropdown;
-	border: 1px solid $dropdown-border-color; //$dropdown-fallback-border
+	border: 1px solid $dropdown-border-color; // $dropdown-fallback-border
 	border-radius: $border-radius;
-	box-shadow: 0 6px 12px rgba(0,0,0,.175);
+	box-shadow: 0 6px 12px rgb(0 0 0 / 17.5%);
 }
 
 .#{$select-ns}-dropdown {
@@ -116,18 +107,24 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		font-size: $font-size-sm;
 		line-height: $line-height-base;
 	}
-	.optgroup:first-child:before {
-		display: none;
-	}
-	.optgroup:before {
-		content: ' ';
-		display:	 block;
-		height: 0;
-		margin: $dropdown-divider-margin-y 0;
-		overflow: hidden;
-		border-top: 1px solid $dropdown-divider-bg;
-		margin-left: $select-padding-dropdown-item-x * -1;
-		margin-right: $select-padding-dropdown-item-x * -1;
+
+	.optgroup {
+		&:first-child { 
+			&::before {
+				display: none;
+			}
+		}
+
+		&::before {
+			content: ' ';
+			display: block;
+			height: 0;
+			margin: $dropdown-divider-margin-y 0;
+			overflow: hidden;
+			border-top: 1px solid $dropdown-divider-bg;
+			margin-left: $select-padding-dropdown-item-x * -1;
+			margin-right: $select-padding-dropdown-item-x * -1;
+		}
 	}
 
 	.create {
@@ -142,16 +139,18 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 .#{$select-ns}-control {
 	@include box-shadow($input-box-shadow);
 	@include transition($input-transition);
-	display:flex;
+
+	display: flex;
 	align-items: center;
 
-	&.dropdown	-active {
+	&.dropdown-active {
 		border-radius: $select-border-radius;
 	}
 
 	.focus &{
 		border-color: $input-focus-border-color;
 		outline: 0;
+
 		@if $enable-shadows {
 			box-shadow: $input-box-shadow, $input-focus-box-shadow;
 		} @else {
@@ -174,13 +173,35 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	min-height: $input-height;
 	display:flex;
 
+	&:not(.form-control) {
+		&:not(.form-select){
+			padding: 0;
+			border: none;
+			height: auto;
+			box-shadow: none;
+			background: none;
+
+			&.single .#{$select-ns}-control{
+				background-image: escape-svg($form-select-indicator);
+				background-repeat: no-repeat;
+				background-position: $form-select-bg-position;
+				background-size: $form-select-bg-size;
+			}
+		}
+	}
+
+	&.form-select,
+	&.single{
+		--ts-pr-caret: #{$form-select-indicator-padding};
+	}
+
 	.input-group-sm > &,
 	&.form-select-sm,
 	&.form-control-sm{
 		min-height: $input-height-sm;
 
 		.#{$select-ns}-control{
-				//padding: $input-padding-y-sm $input-padding-x-sm;
+			// padding: $input-padding-y-sm $input-padding-x-sm;
 			@include border-radius($input-border-radius-sm);
 			@include font-size($input-font-size-sm);
 		}
@@ -199,7 +220,8 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 			// padding-top = ($input-height-sm - border-width - item-height) / 2;
 			// item-height = ($select-line-height * $input-font-size-sm) + ($select-padding-item-y * 2)
 			$border-and-padding: add($input-border-width,$select-padding-item-y) * 2;
-			$ts-select-padding-sm: calc( (#{$input-height-sm} - (#{$select-line-height} * #{$input-font-size-sm}) - #{$border-and-padding})/2);
+			$ts-select-padding-sm: calc( (#{$input-height-sm} - (#{$select-line-height} * #{$input-font-size-sm}) - #{$border-and-padding}) / 2);
+
 			padding-top: $ts-select-padding-sm !important;
 		}
 	}
@@ -207,8 +229,9 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 	&.multi {
 		&.has-items .#{$select-ns}-control {
-			padding-left: calc(#{$select-padding-x} - #{$select-padding-item-x});
 			--ts-pr-min: calc(#{$select-padding-x} - #{$select-padding-item-x});
+
+			padding-left: calc(#{$select-padding-x} - #{$select-padding-item-x});
 		}
 		.#{$select-ns}-control > div {
 			border-radius: calc(#{$select-border-radius} - 1px);
@@ -226,33 +249,12 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	}
 }
 
-
-.#{$select-ns}-wrapper{
-
-	&:not(.form-control):not(.form-select){
-		padding: 0;
-		border: none;
-		height: auto;
-		box-shadow: none;
-		background: none;
-
-		&.single .#{$select-ns}-control{
-			background-image: escape-svg($form-select-indicator);
-			background-repeat: no-repeat;
-			background-position: $form-select-bg-position;
-			background-size: $form-select-bg-size;
-		}
-	}
-
-	&.form-select,
-	&.single{
-		--ts-pr-caret: #{$form-select-indicator-padding};
-	}
-
-}
-
 .#{$select-ns}-wrapper.form-control,
-.#{$select-ns}-wrapper.form-select{
+.#{$select-ns}-wrapper.form-select {
+	padding: 0 !important;
+	height: auto;
+	box-shadow: none;
+	display: flex;
 
 	.#{$select-ns}-control,
 	&.single.input-active .#{$select-ns}-control{

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -1,6 +1,8 @@
 /**
  * Tom Select bootstrap 5
  */
+@use "sass:color";
+@use "sass:map";
 
 // Import Boostrap 5 functions and variables
 $state-valid: map.get($form-validation-states,'valid') !default;

--- a/src/scss/tom-select.default.scss
+++ b/src/scss/tom-select.default.scss
@@ -8,31 +8,34 @@ $select-color-item-active:			#92c836;
 $select-color-item-active-border:	#00578d;
 $select-width-item-border:			1px;
 
-$select-shadow-input:				inset 0 1px 1px rgba(0,0,0,0.1) !default;
-$select-shadow-input-focus:			inset 0 1px 2px rgba(0,0,0,0.15) !default;
+$select-shadow-input:				inset 0 1px 1px rgb(0 0 0 / 10%) !default;
+$select-shadow-input-focus:			inset 0 1px 2px rgb(0 0 0 / 15%) !default;
 
 
 @import "tom-select";
-@include ts-caret();
+@include ts-caret;
 
 .#{$select-ns}-wrapper {
-	display:flex;
-	min-height:$select-line-height + ($select-padding-y*2) + ($select-border-width *2);
+	display: flex;
+	min-height: $select-line-height + ($select-padding-y * 2) + ($select-border-width * 2);
 
 	&.multi {
-
 		&.has-items .#{$select-ns}-control {
+			--ts-pr-min: $padding-x;
+
 			$padding-x: $select-padding-x - 3px;
+			
 			padding-left: $padding-x;
-			--ts-pr-min:$padding-x;
 		}
 
 		.#{$select-ns}-control {
 			[data-value] {
-				text-shadow: 0 1px 0 rgba(0,51,83,0.3);
-				border-radius: 3px;
 				@include selectize-vertical-gradient(#1da7ee, #178ee9);
-				box-shadow: 0 1px 0 rgba(0,0,0,0.2),inset 0 1px rgba(255,255,255,0.03);
+				
+				text-shadow: 0 1px 0 rgb(0 51 83 / 30%);
+				border-radius: 3px;
+				box-shadow: 0 1px 0 rgb(0 0 0 / 20%), inset 0 1px rgb(255 255 255 / 3%);
+
 				&.active {
 					@include selectize-vertical-gradient(#008fd8, #0075cf);
 				}
@@ -48,16 +51,19 @@ $select-shadow-input-focus:			inset 0 1px 2px rgba(0,0,0,0.15) !default;
 			&, .remove {
 				border-color: #e6e6e6;
 			}
+
 			.remove {
 				background: none;
 			}
 		}
 
 	}
+
 	&.single {
 		.#{$select-ns}-control {
-			box-shadow: 0 1px 0 rgba(0,0,0,0.05), inset 0 1px 0 rgba(255,255,255,0.8);
 			@include selectize-vertical-gradient(#fefefe, #f2f2f2);
+
+			box-shadow: 0 1px 0 rgb(0 0 0 / 5%), inset 0 1px 0 rgb(255 255 255 / 80%);
 		}
 	}
 }
@@ -78,8 +84,10 @@ $select-shadow-input-focus:			inset 0 1px 2px rgba(0,0,0,0.15) !default;
 		font-weight: bold;
 		font-size: 0.85em;
 	}
+
 	.optgroup {
 		border-top: 1px solid $select-color-dropdown-border-top;
+
 		&:first-child {
 			border-top: 0 none;
 		}

--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -13,6 +13,9 @@
  *
  */
 
+@use "sass:color";
+@use "sass:math";
+
 
 // base styles
 $select-ns:										'ts' !default;
@@ -38,7 +41,7 @@ $select-color-dropdown-border:					$select-color-border !default;
 $select-color-dropdown-border-top:				#f0f0f0 !default;
 $select-color-dropdown-item-active:				#f5fafd !default;
 $select-color-dropdown-item-active-text: 		#495c68 !default;
-$select-color-dropdown-item-create-text:		rgb(color.red($select-color-text) color.green($select-color-text) color.blue($select-color-text) / 50%) !default;
+$select-color-dropdown-item-create-text:		rgba(color.red($select-color-text), color.green($select-color-text), color.blue($select-color-text), 50%) !default;
 $select-color-dropdown-item-create-active-text:	$select-color-dropdown-item-active-text !default;
 $select-color-optgroup:							$select-color-dropdown !default;
 $select-color-optgroup-text:					$select-color-text !default;

--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -23,7 +23,7 @@ $select-line-height:							18px !default;
 
 $select-color-text:								#303030 !default;
 $select-color-border:							#d0d0d0 !default;
-$select-color-highlight:						rgba(125,168,208,0.2) !default;
+$select-color-highlight:						rgb(125 168 208 / 20%) !default;
 $select-color-input:							#fff !default;
 $select-color-input-full:						$select-color-input !default;
 $select-color-disabled:							#fafafa !default;
@@ -38,7 +38,7 @@ $select-color-dropdown-border:					$select-color-border !default;
 $select-color-dropdown-border-top:				#f0f0f0 !default;
 $select-color-dropdown-item-active:				#f5fafd !default;
 $select-color-dropdown-item-active-text: 		#495c68 !default;
-$select-color-dropdown-item-create-text:		rgba(red($select-color-text), green($select-color-text), blue($select-color-text), 0.5) !default;
+$select-color-dropdown-item-create-text:		rgb(color.red($select-color-text) color.green($select-color-text) color.blue($select-color-text) / 50%) !default;
 $select-color-dropdown-item-create-active-text:	$select-color-dropdown-item-active-text !default;
 $select-color-optgroup:							$select-color-dropdown !default;
 $select-color-optgroup-text:					$select-color-text !default;
@@ -54,8 +54,8 @@ $select-border:									$select-border-width solid $select-color-border !default
 $select-dropdown-border:						1px solid $select-color-dropdown-border !default;
 $select-border-radius:							3px !default;
 
-$select-width-item-border:						0px !default;
-$select-max-height-dropdown:					200px !default;
+$select-width-item-border:						0 !default;
+$select-max-height-dropdown:					200 !default;
 
 $select-padding-x:								8px !default;
 $select-padding-y:								8px !default;
@@ -70,10 +70,10 @@ $select-arrow-size:								5px !default;
 $select-arrow-color:								#808080 !default;
 $select-arrow-offset:							15px !default;
 
-$select-caret-margin:							0px 4px !default;
-$select-caret-margin-rtl:						0px 4px 0px -2px !default;
+$select-caret-margin:							0 4px !default;
+$select-caret-margin-rtl:						0 4px 0 -2px !default;
 
-$select-spinner-size:							30px !default;
+$select-spinner-size:							30 !default;
 $select-spinner-border-size:					5px !default;
 $select-spinner-border-color:					$select-color-border !default;
 
@@ -84,7 +84,7 @@ $select-spinner-border-color:					$select-color-border !default;
 }
 
 @mixin selectize-vertical-gradient($color-top, $color-bottom) {
-    background-color: mix($color-top, $color-bottom, 60%);
+    background-color: color.mix($color-top, $color-bottom, 60%);
     background-image: linear-gradient(to bottom, $color-top, $color-bottom);
     background-repeat: repeat-x;
 }
@@ -99,7 +99,7 @@ $select-spinner-border-color:					$select-color-border !default;
 }
 
 .#{$select-ns}-control {
-	padding-right:	Max( var(--ts-pr-min), calc( var(--ts-pr-clear-button) + var(--ts-pr-caret)) ) !important;
+	padding-right:	max( var(--ts-pr-min), calc( var(--ts-pr-clear-button) + var(--ts-pr-caret)) ) !important;
 }
 
 @mixin ts-caret(){
@@ -109,13 +109,13 @@ $select-spinner-border-color:					$select-color-border !default;
 		.#{$select-ns}-control {
 			--ts-pr-caret: 2rem;
 
-			&:after {
+			&::after {
 				content: ' ';
 				display: block;
 				position: absolute;
 				top: 50%;
 				right: $select-arrow-offset;
-				margin-top: round(-0.5 * $select-arrow-size);
+				margin-top: math.round(-0.5 * $select-arrow-size);
 				width: 0;
 				height: 0;
 				border-style: solid;
@@ -159,7 +159,7 @@ $select-spinner-border-color:					$select-color-border !default;
 	font-family: $select-font-family;
 	font-size: $select-font-size;
 	line-height: $select-line-height;
-	font-smoothing: $select-font-smoothing;
+	font-smoothing: $select-font-smoothing; /* stylelint-disable-line property-no-unknown */
 }
 
 .#{$select-ns}-control,
@@ -175,7 +175,8 @@ $select-spinner-border-color:					$select-color-border !default;
 	border: 0 !important;
     clip: rect(0 0 0 0) !important;
     clip-path: inset(50%) !important;
-    //height: 1px !important;
+
+    // height: 1px !important;
     overflow: hidden !important;
     padding: 0 !important;
     position: absolute !important;


### PR DESCRIPTION
Hi team!

I was getting a Stylelint warning from the `tom-select` SASS/SCSS in our codebase. The SASS linter can either continue to warn or turn off _all warnings for dependencies_, and I wasn't satisfied by that latter option, so I thought I'd bring some linty goodness into the `tom-select` repository.

I've added `stylelint` and its SASS compatibility to the dev dependencies, added a minimal configuration for it that balances ignoring things that aren't worth refactoring for, and made edits to the SCSS files to bring them into spec with the linter.

I don't believe I have functionally changed anything, but you never know! I ran the doc/demo site via `npm start` and everything seems to be behaving itself...

Most tests pass, a few do not but they do not seem related to this change!