### PR TITLE
Adapt Bootstrap 5 SCSS for Bootstrap 5.3+

### DIFF
--- a/src/plugins/dropdown_header/plugin.scss
+++ b/src/plugins/dropdown_header/plugin.scss
@@ -4,7 +4,7 @@
 		position: relative;
 		padding: ($select-padding-dropdown-item-y * 2) $select-padding-dropdown-item-x;
 		border-bottom: 1px solid $select-color-border;
-		background: mix($select-color-dropdown, $select-color-border, 85%);
+		background: color-mix($select-color-dropdown, $select-color-border, 85%);
 		border-radius: $select-border-radius $select-border-radius 0 0;
 	}
 	.dropdown-header-close {

--- a/src/scss/tom-select.bootstrap4.scss
+++ b/src/scss/tom-select.bootstrap4.scss
@@ -28,7 +28,7 @@ $select-color-optgroup: $dropdown-bg !default;
 $select-color-optgroup-text: $dropdown-header-color !default;
 $select-color-optgroup-border: $dropdown-divider-bg !default;
 $select-color-dropdown: $dropdown-bg !default;
-$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 0.8) !default;
+$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 80%) !default;
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -28,7 +28,7 @@ $select-color-optgroup: $dropdown-bg !default;
 $select-color-optgroup-text: $dropdown-header-color !default;
 $select-color-optgroup-border: $dropdown-divider-bg !default;
 $select-color-dropdown: $dropdown-bg !default;
-$select-color-dropdown-border-top: mix($input-border-color, $input-bg, 80%) !default;
+$select-color-dropdown-border-top: color-mix($input-border-color, $input-bg, 80%) !default;
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;
@@ -198,8 +198,8 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		.#{$select-ns}-control{
 			// padding-top = ($input-height-sm - border-width - item-height) / 2;
 			// item-height = ($select-line-height * $input-font-size-sm) + ($select-padding-item-y * 2)
-			$border-and-padding: add($input-border-width,$select-padding-item-y) * 2;
-			$ts-select-padding-sm: calc( (#{$input-height-sm} - (#{$select-line-height} * #{$input-font-size-sm}) - #{$border-and-padding})/2);
+			$border-and-padding: calc(($input-border-width + $select-padding-item-y) * 2);
+			$ts-select-padding-sm: calc((#{$input-height-sm} - (#{$select-line-height} * #{$input-font-size-sm}) - #{$border-and-padding})/2);
 			padding-top: $ts-select-padding-sm !important;
 		}
 	}

--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -84,7 +84,7 @@ $select-spinner-border-color:					$select-color-border !default;
 }
 
 @mixin selectize-vertical-gradient($color-top, $color-bottom) {
-    background-color: mix($color-top, $color-bottom, 60%);
+    background-color: color-mix($color-top, $color-bottom, 60%);
     background-image: linear-gradient(to bottom, $color-top, $color-bottom);
     background-repeat: repeat-x;
 }


### PR DESCRIPTION
The existing code already uses calc() in some places, so using it instead of add() is safe.

Because Bootstrap 5.3 is using more and more CSS variables, we need to use color-mix() which has an good evergreen browser support : https://caniuse.com/?search=color-mix

To maintain Bootstrap 5.0 to 5.2 compatibility for older browsers, a separate "tom-select.bootstrap5.3.scss" file should be create with this code.

-------

Closes #600 #599 #517