### PR TITLE
Disable autocomplete and spellcheck to improve UX

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -247,6 +247,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		setAttr(focus_node,{
 			role:'combobox',
+			spellcheck:'false',
+			autocomplete:"off",
 			'aria-haspopup':'listbox',
 			'aria-expanded':'false',
 			'aria-controls':listboxId


### PR DESCRIPTION
TomSelects is adding a dynamic input field when it has been created from a `<select>` element. The field is required to process the user's tag input. However, this field is not practical for smartphones: It is unnecessary to use a spell checker for tags, and the 'autocomplete' function can produce unexpected inputs.

With this PR I added both attributes.