### PR TITLE
stick to conservative and more compatible syntax

### DIFF
--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -20,7 +20,7 @@ $select-font-size:								13px !default;
 $select-line-height:							18px !default;
 $select-color-text:								#303030 !default;
 $select-color-border:							#d0d0d0 !default;
-$select-color-highlight:						rgb(125 168 208 / 20%) !default;
+$select-color-highlight:						rgb(125, 168, 208, 20%) !default;
 $select-color-input:							#fff !default;
 $select-color-input-full:						$select-color-input !default;
 $select-color-disabled:							#fafafa !default;


### PR DESCRIPTION
sassc ruby can't parse non-comma-separated arguments:

```
SassC::SyntaxError 
Error: Function rgb is missing argument $green.
        on line 23 of node_modules/tom-select/src/scss/tom-select.scss
```

the issue is mentioned in the docs:

> Sass’s special parsing rules for slash-separated values make it difficult to pass variables for $blue or $alpha when using the rgb($red $green $blue / $alpha) signature. Consider using rgb($red, $green, $blue, $alpha) instead.

-- https://sass-lang.com/documentation/modules/#rgb

<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->
