### PR TITLE
fix: remove bottom padding using bootstrap5 styles

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -170,7 +170,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 		&.has-items .#{$select-ns}-control {
 			font-size: $input-font-size-sm;
-			padding-bottom: 0;
+			//padding-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
sm / lg elements padded incorectly when having selected value
