### PR TITLE
fix jquery usage

### DIFF
--- a/src/plugins/drag_drop/plugin.ts
+++ b/src/plugins/drag_drop/plugin.ts
@@ -17,6 +17,7 @@ import TomSelect from '../../tom-select';
 
 export default function(this:TomSelect) {
 	var self = this;
+	var $ = jQuery;
 	if (!$.fn.sortable) throw new Error('The "drag_drop" plugin requires jQuery UI "sortable".');
 	if (self.settings.mode !== 'multi') return;
 


### PR DESCRIPTION
depending on $ being an instance of jQuery is bad since it could be a reference to anything and/or jquery running in noConflict() mode. fixing this by using the jQuery global.

resolves #619.
