### PR TITLE
Add emptyOptionValue configuration option

### DIFF
--- a/doc_src/pages/docs/index.md
+++ b/doc_src/pages/docs/index.md
@@ -197,9 +197,15 @@ create: function(input,callback){
 	</tr>
 	<tr>
 		<td><code>allowEmptyOption</code></td>
-		<td>If true, any options with a "" value will be treated like normal. This defaults to false to accommodate the common &lt;select&gt; practice of having the first empty option to act as a placeholder.</td>
+		<td>If true, any options with value="" (or other value if specified by <code>emptyOptionValue</code>) will be treated like normal. This defaults to false to accommodate the common &lt;select&gt; practice of having the first empty option to act as a placeholder.</td>
 		<td><code>boolean</code></td>
 		<td><code>false</code></td>
+	</tr>
+	<tr>
+		<td><code>emptyOptionValue</code></td>
+		<td>The value of an option that is to be treated as empty in case <code>allowEmptyOption</code> is <code>false</code>.</td>
+		<td><code>string</code></td>
+		<td><code>''</code></td>
 	</tr>
 	<tr>
 		<td><code>loadThrottle</code></td>

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,6 +22,7 @@ export default {
 	selectOnTab: false,
 	preload: null,
 	allowEmptyOption: false,
+	emptyOptionValue: '',
 	//closeAfterSelect: false,
 	refreshThrottle: 300,
 

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -1,5 +1,5 @@
 import defaults from './defaults';
-import { hash_key } from './utils';
+import { hash_key, escape_css } from './utils';
 import { TomOption, TomSettings, RecursivePartial } from './types/index';
 import { iterate } from '@orchidjs/sifter/lib/utils';
 import { TomInput } from './types/index';
@@ -19,8 +19,10 @@ export default function getSettings( input:TomInput, settings_user:RecursivePart
 	var tag_name				= input.tagName.toLowerCase();
 	var placeholder				= input.getAttribute('placeholder') || input.getAttribute('data-placeholder');
 
+	var empty_option_value 		= settings.emptyOptionValue;
+
 	if (!placeholder && !settings.allowEmptyOption) {
-		let option		= input.querySelector('option[value=""]');
+		let option		= input.querySelector(`option[value="${escape_css(empty_option_value)}"]`);
 		if( option ){
 			placeholder = option.textContent;
 		}
@@ -69,7 +71,7 @@ export default function getSettings( input:TomInput, settings_user:RecursivePart
 
 			var value = hash_key(option.value);
 			if ( value == null ) return;
-			if ( !value && !settings.allowEmptyOption) return;
+			if ( option.value == settings.emptyOptionValue && !settings.allowEmptyOption) return;
 
 			// if the option already exists, it's probably been
 			// duplicated in another optgroup. in this case, push

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -11,6 +11,7 @@ import {
 	hash_key,
 	get_hash,
 	escape_html,
+	escape_css,
 	debounce_events,
 	getSelection,
 	preventDefault,
@@ -2207,7 +2208,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		const self = this;
 		var option, label;
 
-		const empty_option = self.input.querySelector('option[value=""]') as HTMLOptionElement;
+		const empty_option = self.input.querySelector(`option[value="${escape_css(self.settings.emptyOptionValue)}"]`) as HTMLOptionElement;
 
 		if( self.is_select_tag ){
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -30,6 +30,7 @@ export type TomSettings = {
 	selectOnTab				: boolean,
 	preload					: boolean|string,
 	allowEmptyOption		: boolean,
+	emptyOptionValue		: string,
 	closeAfterSelect		: boolean,
 	refreshThrottle			: number,
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,11 @@ export const escape_html = (str:string):string => {
 		.replace(/"/g, '&quot;');
 };
 
+/**
+ * Escapes a string for use within a CSS selector.
+ */
+export const escape_css = (str:string):string => CSS.escape(str);
+
 
 /**
  * use setTimeout if timeout > 0 


### PR DESCRIPTION
This change allows for an empty option that does not necessarily have a `value=""`, but any specified string.
