### PR TITLE
Fix type of TomSettings.maxOptions

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -22,7 +22,7 @@ export type TomSettings = {
 	highlight				: boolean,
 	openOnFocus				: boolean,
 	shouldOpen				: boolean,
-	maxOptions				: number,
+	maxOptions				: null|number,
 	maxItems				: null|number,
 	hideSelected			: boolean,
 	duplicates				: boolean,


### PR DESCRIPTION
The docs state that maxOptions can be number or null,.
This code:
```ts
this.ProductSelect2 = new TomSelect(exampleSelectInput, { maxOptions: null });
```
Currently generates an error since settings.ts defines it as number only.

