### PR TITLE
Issue 634 patch: updates for bootstrap dark mode support

### DIFF
--- a/doc_src/css/stylesheet.scss
+++ b/doc_src/css/stylesheet.scss
@@ -163,6 +163,8 @@ pre[class*="language-"]{
 .theme-selector-input{
 	float:right;
 	margin-top: 0.5rem;
+	min-width: 14em;
+	width: auto;
 }
 
 /**

--- a/doc_src/js/index.js
+++ b/doc_src/js/index.js
@@ -35,9 +35,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 	var themes			= window.themes || ['bootstrap5','bootstrap4','default'];
 	var theme_options = {
+		bootstrap5D: 'Bootstrap 5 Dark',
 		bootstrap5: 'Bootstrap 5',
-		bootstrap4: 'Bootstrap 4',
-		default: 'Default',
+        bootstrap4: 'Bootstrap 4',
+        default: 'Default',
 	};
 
 	var theme			= localStorage.getItem('theme');
@@ -97,11 +98,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
 		link				= document.createElement('link');
 		link.id				= 'select-theme';
-
+		let clean_theme;
+		let color_mode;
+		switch(theme) {
+			case 'bootstrap5D':
+				color_mode = 'dark'
+				clean_theme = 'bootstrap5'
+				break;
+			default:
+				color_mode = 'light'
+				clean_theme = theme
+		}
+		
 		link.setAttribute('rel','stylesheet');
-		link.setAttribute('href','/css/tom-select.' + theme + '.css');
+		link.setAttribute('href','/css/tom-select.' + clean_theme + '.css');
 		document.getElementsByTagName('head')[0].appendChild(link);
-
+		document.getElementsByTagName('body')[0].dataset.bsTheme = color_mode;
 	}
 
 

--- a/doc_src/pages/examples/styling.njk
+++ b/doc_src/pages/examples/styling.njk
@@ -2,7 +2,7 @@
 title: Styling Examples
 nav_title: Styling
 tags: demo
-script: <script>themes = ['bootstrap5','bootstrap4'];</script>
+script: <script>themes = ['bootstrap5','bootstrap5D','bootstrap4'];SetTheme('bootstrap5');</script>
 ---
 
 

--- a/src/plugins/dropdown_header/plugin.scss
+++ b/src/plugins/dropdown_header/plugin.scss
@@ -19,6 +19,6 @@
 	}
 
 	.dropdown-header-close:hover {
-		color: darken($select-color-text, 25%);
+		filter: contrast(200%);
 	}
 }

--- a/src/scss/_items.scss
+++ b/src/scss/_items.scss
@@ -54,8 +54,8 @@
 
 	.#{$select-ns}-wrapper.multi.disabled & > div {
 		&, &.active {
-			color: lighten(desaturate($select-color-item-text, 100%), $select-lighten-disabled-item-text);
-			background: lighten(desaturate($select-color-item, 100%), $select-lighten-disabled-item);
+			color: $select-color-item-text, $select-lighten-disabled-item-text;
+			background: $select-color-item, $select-lighten-disabled-item;
 			border: $select-width-item-border solid lighten(desaturate($select-color-item-border, 100%), $select-lighten-disabled-item-border);
 		}
 	}

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -10,15 +10,14 @@ $select-font-family: inherit !default;
 $select-font-size: inherit !default;
 $select-line-height: $input-btn-line-height !default; // formerly line-height-computed
 
-$select-color-text: $gray-800 !default;
+$select-color-text: $input-color !default; 
 $select-color-highlight: rgba(255, 237, 40, 40%) !default;
 $select-color-input: $input-bg !default;
-$select-color-input-full: $input-bg !default;
 $select-color-disabled: $input-disabled-bg !default;
-$select-color-item: #efefef !default;
+$select-color-item: #b9b9b9 !default;
 $select-color-item-border: $border-color !default;
 $select-color-item-active: $component-active-bg !default;
-$select-color-item-active-text: #fff !default;
+$select-color-item-active-text: $input-color !default; 
 $select-color-item-active-border: rgba(0, 0, 0, 0%) !default;
 $select-color-optgroup: $dropdown-bg !default;
 $select-color-optgroup-text: $dropdown-header-color !default;
@@ -28,6 +27,7 @@ $select-color-dropdown-border-top: color-mix($input-border-color, $input-bg, 80%
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;
+$select-color-dropdown-item-create-text: rgba($input-color, 50%) !default;
 $select-opacity-disabled: 0.5 !default;
 $select-border: 1px solid $input-border-color !default;
 $select-border-radius: $input-border-radius !default;


### PR DESCRIPTION
src/scss/tom-select.bootstrap5.scss
set $select-color-text and $select-color-item-active-text to '$input-color' as text, rather than hard-coded hex values
tweak $select-color-item so that it is OK both in light & dark mode
define $select-color-dropdown-item-create-text as rgba($input-color, 50%) to support variable color name

src/scss/_items.scss
remove SASS functions for calculating offset colors, since we now may have a variable rather than a hex number.

src/plugins/dropdown_header/plugin.scss
switch hover to using a CSS filter (200% contrast), rather than SASS darken function, since we may now be passing a variable rather than a hex value

doc_src/pages/examples/styling.njk
add in example for Bootstrap 5 dark mode

doc_src/js/index.js
update style picker to allow for Bootstrap 5 dark mode

doc_src/css/stylesheet.scss
add a min-width & auto-wide on the theme select box, it's shrinking to weird sizes without this
