### PR TITLE
Fixes css/sass variable interpolation in tom-select.default.scss

### DIFF
--- a/src/scss/tom-select.default.scss
+++ b/src/scss/tom-select.default.scss
@@ -21,7 +21,7 @@ $select-shadow-input-focus:			inset 0 1px 2px rgba(0, 0, 0, 15%) !default;
 
 			padding-left: $padding-x;
 
-			--ts-pr-min: $padding-x;
+			--ts-pr-min: #{$padding-x};
 		}
 
 		.#{$select-ns}-control {


### PR DESCRIPTION
<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->
I believe this fixes #683, where I noticed that a SASS variable didn't get replaced in the package's `dist` file output. I haven't used SASS/SCSS in a while so I could be wrong. I'd be happy to address this differently if there's a different way to fix this.