### PR TITLE
Change how dropdown_input works to fix #672 and #679

### DIFF
--- a/src/plugins/dropdown_input/plugin.scss
+++ b/src/plugins/dropdown_input/plugin.scss
@@ -1,13 +1,4 @@
 .plugin-dropdown_input{
-
-	&.focus.dropdown-active .#{$select-ns}-control{
-		box-shadow: none;
-		border: $select-border;
-		@if variable-exists(input-box-shadow) {
-			box-shadow: $input-box-shadow;
-		}
-	}
-
 	.dropdown-input {
 		border: 1px solid $select-color-border;
 		border-width: 0 0 1px;
@@ -18,26 +9,7 @@
 		background: transparent;
 	}
 
-	&.focus .#{$select-ns}-dropdown .dropdown-input{
-		@if variable-exists(input-focus-border-color) {
-			border-color: $input-focus-border-color;
-			outline: 0;
-			@if $enable-shadows {
-				box-shadow: $input-box-shadow, $input-focus-box-shadow;
-			} @else {
-				box-shadow: $input-focus-box-shadow;
-			}
-		}
-	}
-
-	.items-placeholder{
-		border: 0 none !important;
-		box-shadow: none !important;
-		width: 100%;
-	}
-
-	&.has-items .items-placeholder,
-	&.dropdown-active .items-placeholder{
-		display: none !important;
+	& .#{$select-ns}-dropdown .dropdown-input:focus-visible{
+		outline: none;
 	}
 }

--- a/src/plugins/dropdown_input/plugin.ts
+++ b/src/plugins/dropdown_input/plugin.ts
@@ -22,10 +22,13 @@ export default function (this: TomSelect) {
 	const self = this;
 	const dropdownInputWrap = getDom('<div class="dropdown-input-wrap">');
 
-	const delayedRefocus = () => {
+	const ignoreFocusUntilNextTick = () => {
 		self.ignoreFocus = true;
 		setTimeout(() => {
-			self.focus_node.focus();
+			// Firefox needs to refocus on the next tick
+			if (document.activeElement != self.focus_node) {
+				self.focus_node.focus();
+			}
 			self.ignoreFocus = false;
 		}, 0);
 	}
@@ -34,7 +37,8 @@ export default function (this: TomSelect) {
 		if (!dropdownInputWrap.contains(self.focus_node)) {
 			dropdownInputWrap.append(self.focus_node);
 			addClasses(self.focus_node, 'dropdown-input');
-			delayedRefocus();
+			ignoreFocusUntilNextTick();
+			self.focus_node.focus();
 			self.control_input.placeholder = self.settings.placeholder;
 			self.isInputHidden = false;
 			removeClasses(self.wrapper, 'input-hidden');
@@ -45,7 +49,8 @@ export default function (this: TomSelect) {
 		if (!self.control.contains(self.focus_node)) {
 			removeClasses(self.focus_node, 'dropdown-input');
 			self.control.append(self.focus_node);
-			delayedRefocus();
+			ignoreFocusUntilNextTick();
+			self.focus_node.focus();
 			self.inputState();
 		}
 	}

--- a/src/plugins/dropdown_input/plugin.ts
+++ b/src/plugins/dropdown_input/plugin.ts
@@ -18,58 +18,58 @@ import * as constants from '../../constants';
 import { getDom, addClasses, removeClasses } from '../../vanilla';
 import { preventDefault } from '../../utils';
 
-export default function(this:TomSelect) {
+export default function (this: TomSelect) {
 	const self = this;
 	const dropdownInputWrap = getDom('<div class="dropdown-input-wrap">');
 
-	const moveToDropdown = ()=>{
+	const delayedRefocus = () => {
+		self.ignoreFocus = true;
+		setTimeout(() => {
+			self.focus_node.focus();
+			self.ignoreFocus = false;
+		}, 0);
+	}
+
+	const moveToDropdown = () => {
 		if (!dropdownInputWrap.contains(self.focus_node)) {
 			dropdownInputWrap.append(self.focus_node);
-			addClasses( self.focus_node, 'dropdown-input');
-			self.ignoreFocus = true;
-			setTimeout(() => {
-				self.focus_node.focus();
-				self.ignoreFocus = false;
-			}, 0);
+			addClasses(self.focus_node, 'dropdown-input');
+			delayedRefocus();
 			self.control_input.placeholder = self.settings.placeholder;
 			self.isInputHidden = false;
-			removeClasses( self.wrapper, 'input-hidden');		
+			removeClasses(self.wrapper, 'input-hidden');
 		}
 	}
-	const moveToControl = ()=>{
+	
+	const moveToControl = () => {
 		if (!self.control.contains(self.focus_node)) {
-			removeClasses( self.focus_node, 'dropdown-input');
+			removeClasses(self.focus_node, 'dropdown-input');
 			self.control.append(self.focus_node);
-			self.ignoreFocus = true;
-			setTimeout(() => {
-				self.focus_node.focus();
-				self.ignoreFocus = false;
-			}, 0);
+			delayedRefocus();
 			self.inputState();
 		}
 	}
 
 	self.settings.shouldOpen = true; // make sure the input is shown even if there are no options to display in the dropdown
 
-	self.hook('before','setup',()=>{
+	self.hook('before', 'setup', () => {
 		self.dropdown.insertBefore(dropdownInputWrap, self.dropdown.firstChild);
 	});
 
-	self.on('initialize',()=>{
+	self.on('initialize', () => {
 		// Change parent depending on if dropdown is visible
 		self.on('dropdown_open', moveToDropdown);
 		self.on('dropdown_close', moveToControl);
 		// Make sure we can still open on keydown
-		self.focus_node.addEventListener('keydown', (evt:KeyboardEvent) =>{
-			switch( evt.keyCode ){
+		self.focus_node.addEventListener('keydown', (evt: KeyboardEvent) => {
+			switch (evt.keyCode) {
 				case constants.KEY_DOWN:
 					if (!self.isOpen) {
-						preventDefault(evt,true);
+						preventDefault(evt, true);
 						self.open();
 					}
-				return;					
+					return;
 			}
 		});
 	});
-
 };

--- a/test/tests/plugins/dropdown_input.js
+++ b/test/tests/plugins/dropdown_input.js
@@ -5,15 +5,12 @@ describe('plugin: dropdown_input', function() {
 
 	it_n('dropdown should open onclick', async () => {
 		let test = setup_test('<input value="a,b" tabindex="1" placeholder="test placeholder" />', {plugins: ['dropdown_input']});
-		let placeholder = test.instance.control.querySelector('.items-placeholder');
 
-		assert.isFalse( isVisible(placeholder),'items-placeholder should not be visible');
-		assert.isTrue( test.instance.dropdown.contains(test.instance.control_input), 'control_input should be in dropdown');
-
+		assert.isFalse( test.instance.dropdown.contains(test.instance.control_input), 'control_input should not be in dropdown');
 		await asyncClick(test.instance.control);
 		assert.equal(test.instance.isOpen, true);
 		assert.equal(document.activeElement, test.instance.control_input);
-
+		assert.isTrue( test.instance.dropdown.contains(test.instance.control_input), 'control_input should be in dropdown');
 	});
 
 	it_n('dropdown should open onclick without available options', async () => {
@@ -109,12 +106,8 @@ describe('plugin: dropdown_input', function() {
 			plugins: ['dropdown_input'],
 		});
 
-		let placeholder = test.instance.control.querySelector('.items-placeholder');
-		assert.isTrue( isVisible(placeholder),'items-placeholder should be visible');
-
 		await asyncClick( test.instance.control );
 		assert.isTrue( test.instance.isOpen );
-		assert.isFalse( isVisible(placeholder),'items-placeholder should not be visible');
 
 		await asyncType('[escape]');
 		assert.isFalse( test.instance.isOpen, 'not closed' );
@@ -174,5 +167,19 @@ describe('plugin: dropdown_input', function() {
 		await waitFor(10);
 
 		assert.equal( test.instance.items.length, 3);
+	});
+
+	it_n('update active descendent on [down] and [up]', async () => {
+		var test = setup_test('AB_Single', {plugins: ['dropdown_input']});
+		let lastActiveDescendant = "";
+		await asyncClick(test.instance.control);
+		await asyncType('[down]');
+		assert.isTrue(test.instance.focus_node.getAttribute("aria-activedescendant") != lastActiveDescendant);
+		lastActiveDescendant = test.instance.focus_node.getAttribute("aria-activedescendant");
+		await asyncType('[down]');
+		assert.isTrue(test.instance.focus_node.getAttribute("aria-activedescendant") != lastActiveDescendant);
+		lastActiveDescendant = test.instance.focus_node.getAttribute("aria-activedescendant");
+		await asyncType('[up]');
+		assert.isTrue(test.instance.focus_node.getAttribute("aria-activedescendant") != lastActiveDescendant);
 	});
 });

--- a/test/tests/plugins/dropdown_input.js
+++ b/test/tests/plugins/dropdown_input.js
@@ -169,7 +169,14 @@ describe('plugin: dropdown_input', function() {
 		assert.equal( test.instance.items.length, 3);
 	});
 
-	it_n('update active descendent on [down] and [up]', async () => {
+	it_n('focus_node and control_input is the same', async () => {
+		var test = setup_test('AB_Single', {plugins: ['dropdown_input']});
+		assert.equal(test.instance.focus_node, test.instance.control_input, 'focus_node is equal to control_input');
+		await asyncClick(test.instance.control);
+		assert.equal(test.instance.focus_node, test.instance.control_input, 'focus_node is equal to control_input');
+	});
+
+	it_n('should update active descendent on [down] and [up]', async () => {
 		var test = setup_test('AB_Single', {plugins: ['dropdown_input']});
 		let lastActiveDescendant = "";
 		await asyncClick(test.instance.control);
@@ -181,5 +188,14 @@ describe('plugin: dropdown_input', function() {
 		lastActiveDescendant = test.instance.focus_node.getAttribute("aria-activedescendant");
 		await asyncType('[up]');
 		assert.isTrue(test.instance.focus_node.getAttribute("aria-activedescendant") != lastActiveDescendant);
+	});
+
+	it_n('label should be connected to input', async () => {
+		var test = setup_test('<label for="select1">Testlabel</label><select class="setup-here" id="select1" multiple></select>', {plugins: ['dropdown_input']});
+		assert.equal( test.instance.control_input.labels.length, 1, 'control_input should have at least one label');
+		await asyncClick(test.instance.control);
+		assert.equal(test.instance.isOpen, true);
+		assert.equal(document.activeElement, test.instance.control_input);
+		assert.isTrue( test.instance.control_input.labels.length > 0, 'control_input should have at least one label');
 	});
 });


### PR DESCRIPTION
Changes dropdown_input to only use one input and keep focus on the input. This way aria-attributes are on the focused element at all times. 

This also changes how dropdown_input is styled, using a style more similar to Select2, where focus is still on the control.
Added a test for #672, not sure about how to write a test for #679.
![image](https://github.com/orchidjs/tom-select/assets/13048857/747446e5-e5f4-4131-a5c0-6472592d91b0)
