### PR TITLE
fix typescript 5.5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "whitedigital-eu-tom-select",
+  "name": "tom-select",
   "keywords": [
     "select",
     "ui",
@@ -60,7 +60,7 @@
     "grunt-replace": "^2.0.0",
     "grunt-sass": "^3.1.0",
     "grunt-shell": "^4.0.0",
-    "husky": "^7.0.3",
+    "husky": "^8.0.3",
     "icon-blender": "^1.0.0-beta.4",
     "jsdom": "^22.1.0",
     "karma": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tom-select",
+  "name": "whitedigital-eu-tom-select",
   "keywords": [
     "select",
     "ui",
@@ -60,7 +60,7 @@
     "grunt-replace": "^2.0.0",
     "grunt-sass": "^3.1.0",
     "grunt-shell": "^4.0.0",
-    "husky": "^8.0.3",
+    "husky": "^7.0.3",
     "icon-blender": "^1.0.0-beta.4",
     "jsdom": "^22.1.0",
     "karma": "^6.4.2",

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -27,10 +27,7 @@ export const getDom = ( query:any ):HTMLElement => {
 };
 
 export const isHtmlString = (arg:any): boolean => {
-	if( typeof arg === 'string' && arg.indexOf('<') > -1 ){
-		return true;
-	}
-	return false;
+	return typeof arg === 'string' && arg.indexOf('<') > -1;
 }
 
 export const escapeQuery = (query:string):string => {
@@ -97,7 +94,7 @@ export const classesArray = (args:string[]|string[][]):string[] => {
 	var classes:string[] = [];
 	iterate( args, (_classes) =>{
 		if( typeof _classes === 'string' ){
-			_classes = _classes.trim().split(/[\11\12\14\15\40]/);
+			_classes = _classes.trim().split(/[\t\n\f\r\s]/);
 		}
 		if( Array.isArray(_classes) ){
 			classes = classes.concat(_classes);


### PR DESCRIPTION
<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->

This is a fix for an error after upgrading to typescript 5.5:
```
../node_modules/tom-select/src/vanilla.ts:100:51 - error TS1536: Octal escape sequences and backreferences are not allowed in a character class. If this was intended as an escape sequence, use the syntax '\x20' instead.

100    _classes = _classes.trim().split(/[\11\12\14\15\40]/);
```

I have tested the solution in one of my projects and it resolves the typescript error.