### PR TITLE
Update bootstrap5 sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "autoprefixer": "^10.4.16",
     "bootstrap": "npm:bootstrap@4",
     "bootstrap-sass": "^3.4.3",
-    "bootstrap5": "npm:bootstrap@^5.3.2",
+    "bootstrap5": "npm:bootstrap@^5.3.3",
     "broken-link-checker": "^0.7.8",
     "chai": "^4.3.10",
     "cssnano": "^6.0.0",

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -61,19 +61,10 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 			border-color: $border-color;
 		}
 
-		&:not(.single) {
-			background-image: escape-svg($icon);
-			background-position: right $input-height-inner-quarter center;
-			background-size: $input-height-inner-half $input-height-inner-half;
-			background-repeat: no-repeat;
-		}
-
-		&.single {
-			background-image: escape-svg($form-select-indicator), escape-svg($icon);
-			background-position: $form-select-bg-position, $form-select-feedback-icon-position;
-			background-size: $form-select-bg-size, $form-select-feedback-icon-size;
-			background-repeat: no-repeat;
-		}
+		background-image: escape-svg($form-select-indicator), escape-svg($icon);
+		background-position: $form-select-bg-position, $form-select-feedback-icon-position;
+		background-size: $form-select-bg-size, $form-select-feedback-icon-size;
+		background-repeat: no-repeat;
 
 		&.focus .#{$select-ns}-control {
 			box-shadow: $focus-box-shadow

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -28,7 +28,7 @@ $select-color-dropdown-border-top: color-mix($input-border-color, $input-bg, 80%
 $select-color-dropdown-item-active: $dropdown-link-hover-bg !default;
 $select-color-dropdown-item-active-text: $dropdown-link-hover-color !default;
 $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !default;
-$select-opacity-disabled: 0.5 !default;
+$select-opacity-disabled: 1 !default;
 $select-border: 1px solid $input-border-color !default;
 $select-border-radius: $input-border-radius !default;
 $select-width-item-border: 0 !default;
@@ -223,9 +223,13 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		display: flex;
 		border: none !important;
 
-		&:not(.disabled) .#{$select-ns}-control,
+		.#{$select-ns}-control,
 		&:not(.disabled).single.input-active .#{$select-ns}-control {
 			background: transparent !important; // let the background of .form-select show through
+		}
+
+		&.disabled {
+			background-color: $select-color-disabled;
 		}
 	}
 }

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -54,8 +54,12 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 	.was-validated :#{$state} + .#{$select-ns}-wrapper {
 		$color: map-get($state-map,'color');
 		$icon: map-get($state-map,'icon');
+		$focus-box-shadow: map-get($state-map,'focus-box-shadow');
+		$border-color: map-get($state-map,'border-color');
 
-		border-color: $color;
+		.#{$select-ns}-control {
+			border-color: $border-color;
+		}
 
 		&:not(.single) {
 			background-image: escape-svg($icon);
@@ -72,8 +76,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		}
 
 		&.focus .#{$select-ns}-control {
-			border-color: $color;
-			box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity);
+			box-shadow: $focus-box-shadow
 		}
 	}
 }
@@ -150,7 +153,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 .#{$select-ns}-wrapper {
 	min-height: $input-height;
 	display:flex;
-	
+
 	.input-group-sm > &,
 	&.form-select-sm,
 	&.form-control-sm {
@@ -221,17 +224,13 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		--ts-pr-caret: #{$form-select-indicator-padding};
 	}
 
-	&.form-control, 
+	&.form-control,
 	&.form-select {
 		padding:0 !important;
 		height: auto;
 		box-shadow: none;
 		display: flex;
-
-		.#{$select-ns}-control,
-		&.single.input-active .#{$select-ns}-control {
-			border:		none !important;
-		}
+		border: none !important;
 
 		&:not(.disabled) .#{$select-ns}-control,
 		&:not(.disabled).single.input-active .#{$select-ns}-control {


### PR DESCRIPTION
This PR addresses some strange behavior I saw around bootstrap 5 styling. 
# Fixes
## Case 1: Border Highlight
If the classes `form-select` or `form-control` were applied to the wrapper, then the highlight box around the select would be slightly thinner than should be. 

![image](https://github.com/user-attachments/assets/6edfda39-21cb-4f90-9f30-5b2403464d5a)

![image](https://github.com/user-attachments/assets/ed788a84-9039-4ef4-a383-0eb28c365485)

The issue was not present if `form-select` or `form-control` were not provided.

## Case 2
When `form-select` and `form-control` are omitted the border only changes color when clicked, and no icon is present.

![image](https://github.com/user-attachments/assets/29999db5-2c1b-412a-b386-f64f10f1d9a7)
![image](https://github.com/user-attachments/assets/91ed0cb9-97ef-460d-bcfd-d399269fdc2a)

![image](https://github.com/user-attachments/assets/44f2be2d-73c3-47bb-ba7a-e39d56e3106e)
![image](https://github.com/user-attachments/assets/d830b6b6-502b-49c2-afdb-fb7c903d0ac1)

## Case 3
When `form-select` and `form-control` are present, the highlight box does not appear when focused

![image](https://github.com/user-attachments/assets/91ed0cb9-97ef-460d-bcfd-d399269fdc2a)

![image](https://github.com/user-attachments/assets/7a06382c-dc0e-4b3d-adc4-34da35c933a3)

# Broken?
My changes are not perfect, as for example:
- When you have a validity class but no `form-select` or `form-control`, you won't see the icon

![image](https://github.com/user-attachments/assets/29999db5-2c1b-412a-b386-f64f10f1d9a7)
![image](https://github.com/user-attachments/assets/91ed0cb9-97ef-460d-bcfd-d399269fdc2a)

![image](https://github.com/user-attachments/assets/3e08f563-17f6-4042-8621-532d484f0951)
![image](https://github.com/user-attachments/assets/fffd2be1-77d8-4d73-aebb-a3ddde650584)

I don't use sass very often, so open to improvements, but figured I'd give it a first shot. Let me know what you think!
