### PR TITLE
Set overflow:auto for long lines

### DIFF
--- a/src/scss/_items.scss
+++ b/src/scss/_items.scss
@@ -44,6 +44,7 @@
 		background: $select-color-item;
 		color: $select-color-item-text;
 		border: $select-width-item-border solid $select-color-item-border;
+		overflow: auto;
 
 		&.active {
 			background: $select-color-item-active;


### PR DESCRIPTION
For long items I can't click remove item button (x)
![image](https://github.com/user-attachments/assets/24a984a6-b2a7-42a6-83cd-46681d41ecbb)


After PR is merged it will looks like
![image](https://github.com/user-attachments/assets/a3e93554-8eb6-40df-b227-2c7b6e6798f3)
