### PR TITLE
Fix `input.value undefined`

### DIFF
--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -147,7 +147,7 @@ export default function getSettings( input:TomInput, settings_user:RecursivePart
 		const data_raw = input.getAttribute(attr_data);
 
 		if (!data_raw) {
-			var value = input.value.trim() || '';
+			var value = input.value ? input.value.trim() : '';
 			if (!settings.allowEmptyOption && !value.length) return;
 			const values = value.split(settings.delimiter);
 


### PR DESCRIPTION
Fix error when using `trim()` on an undefined value.

![image](https://github.com/user-attachments/assets/143ebe3a-9846-471d-a0cc-3f6ab9c271b9)

I don't know if you guys accept [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for browser compatibility.  
eg: 
```js
input.value?.trim() ?? ''
```
So I've ended up using a simple ternary operator.