### PR TITLE
[Docs] Fix load once load function override

### DIFF
--- a/doc_src/pages/examples/remote.njk
+++ b/doc_src/pages/examples/remote.njk
@@ -135,7 +135,7 @@ new TomSelect('#select-state',{
 				.then(response => response.json())
 				.then(json => {
 					callback(json.result.list);
-					self.settings.load = null;
+					self.settings.load = (query, callback) => callback();
 				}).catch(()=>{
 					callback();
 				});


### PR DESCRIPTION
Currently the load once function docs example makes it load just once, however the loading icon remains present the second time its searched.

See ![ed7e71ef-c164-4add-acca-985c26de85a9](https://github.com/user-attachments/assets/4d8a4f5b-f6bf-4061-8627-c42bff965e69)