### PR TITLE
Add style property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "dist/cjs/tom-select.complete.js",
   "module": "dist/esm/tom-select.complete.js",
   "browser": "dist/js/tom-select.complete.js",
+  "style": "dist/css/tom-select.default.css",
   "exports": {
     ".": {
       "import": "./dist/esm/tom-select.complete.js",


### PR DESCRIPTION
As suggested in #771. This doesn't cover the case of someone wanting to use the Bootstrap styles; they'd need to manually configure their bundler/etc. to use those. In general, I'd still advise folks to explicitly import the styles that they want.