### PR TITLE
Expose src/ in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
       "import": "./dist/esm/plugins/*",
       "require": "./dist/cjs/plugins/*"
     },
+    "./src/*": "./src/*",
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This resolves a technically-breaking change introduced in #800. The addition of `exports` to `package.json` meant that files in `src/` were no longer importable, but apparently some people were relying on this in the wild.

In the next major version (v3) we should consider removing this in favor of making folks always import from `dist/`.

Closes #809.