### PR TITLE
Add unit to CSS zero-length variables

### DIFF
--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -81,8 +81,8 @@ $select-spinner-border-color:					$select-color-border !default;
 @import "../plugins/remove_button/plugin.scss";
 
 :root {
-	--ts-pr-clear-button: 0;
-	--ts-pr-caret: 0;
+	--ts-pr-clear-button: 0em;
+	--ts-pr-caret: 0rem;
 	--ts-pr-min: .75rem;
 }
 

--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -81,8 +81,8 @@ $select-spinner-border-color:					$select-color-border !default;
 @import "../plugins/remove_button/plugin.scss";
 
 :root {
-	--ts-pr-clear-button: 0em;
-	--ts-pr-caret: 0rem;
+	--ts-pr-clear-button: 0px;
+	--ts-pr-caret: 0px;
 	--ts-pr-min: .75rem;
 }
 


### PR DESCRIPTION
Unitless values make CSS computations fail and return zero, which impacts `ts-wrapper`’s end padding if either the clear button or caret is missing.

This PR adds the same unit used when the variable is not zero.

Fixes https://github.com/orchidjs/tom-select/issues/757