### PR TITLE
Fix dropdown scrolling to top when the virtual scroll plugin fetch next page

### DIFF
--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -1,5 +1,5 @@
 /**
- * Plugin: "restore_on_backspace" (Tom Select)
+ * Plugin: "virtual_scroll" (Tom Select)
  * Copyright (c) contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
@@ -148,6 +148,18 @@ export default function(this:TomSelect) {
 		orig_loadCallback.call( self, options, optgroups);
 
 		loading_more = false;
+	});
+
+
+	// as the “loading_more” element will be removed from the dropdown,
+	// we activate the previous option if needed
+	// to avoid the dropdown being scrolled back to the first one
+	self.hook('before','refreshOptions',()=>{
+
+		if (self.activeOption && "option" !== self.activeOption.getAttribute("role")) {
+			self.setActiveOption(self.activeOption.previousElementSibling as HTMLElement);
+		}
+
 	});
 
 

--- a/test/tests/plugins/virtual_scroll.js
+++ b/test/tests/plugins/virtual_scroll.js
@@ -27,9 +27,9 @@ describe('plugin: virtual_scroll', function() {
 
 	it_n('load more data while scrolling',async ()=>{
 
-		var load_calls = 0;
+		let load_calls = 0;
 
-		var test = setup_test('<input>',{
+		const test = setup_test('<input>',{
 			plugins:['virtual_scroll'],
 			labelField: 'value',
 			valueField: 'value',
@@ -53,18 +53,21 @@ describe('plugin: virtual_scroll', function() {
 		await asyncType('a');
 		await waitFor(100); // wait for data to load
 		assert.equal( Object.keys(test.instance.options).length,20,'should load first set of data');
-		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 1, 'should have loading-more-reuslts template');
+		const loadingMoreIndicator = test.instance.dropdown_content.querySelector('.loading-more-results');
+		assert.isNotNull( loadingMoreIndicator, 'should have loading_more template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.no-more-results').length, 0 ,'should not have no-more-results template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.option').length, 21 ,'Should display 20 options plus .loading-more-results');
 
 		assert.equal( load_calls, 1);
 
+		const lastOption = loadingMoreIndicator.previousElementSibling;
 
 		// load second set of data for "a"
-		test.instance.scroll(1000,'auto'); // scroll to bottom
+		test.instance.setActiveOption(loadingMoreIndicator); // scroll to bottom
 		await waitFor(500); // wait for scroll + more data to load
 		assert.equal( Object.keys(test.instance.options).length, 40,'should load second set of data');
-		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 0, 'should not have loading-more-reuslts template');
+		assert.equal( lastOption, test.instance.activeOption, 'previous dataset’s last option should be active')
+		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 0, 'should not have loading_more template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.no-more-results').length, 1 ,'should have no-more-results template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.option').length, 31 ,'Should display 30 options plus .no-more-results');
 		assert.equal( load_calls, 2);
@@ -79,7 +82,7 @@ describe('plugin: virtual_scroll', function() {
 
 		// load first set of data for "b"
 		await asyncType('\bb');
-		await waitFor(100); // wait for data to load
+		await waitFor(500); // wait for data to load
 		assert.equal( Object.keys(test.instance.options).length,20,'should load new set of data for "b"');
 		assert.equal( load_calls, 3);
 	});


### PR DESCRIPTION
Fixes #556 (closed for inactivity but still present).

I stumbled upon two distinct issues when investigating this one:

- the `lastQuery` property was used for checking the UI staleness, as such it was often reset independently of the search query. When the virtual scroll plugin triggers `refreshOptions` the UI is stale so the first option is activated and scrolled to, while it shouldn’t happen since the query didn’t change. This is fixed by splitting the staleness check in a `isDropdownContentStale` property, which is updated independently of `lastQuery`.
- the “loading_more” element is made so that you can select it when navigating using the keyboard. Problem is, it will be removed by `refreshOptions` which then won’t find it in the dropdown and activate — and scroll to — the first option.