### PR TITLE
When sync(true) is called, it should retain allowEmptyOption setting

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -541,7 +541,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	 */
 	sync(get_settings:boolean=true):void{
 		const self		= this;
-		const settings	= get_settings ? getSettings( self.input, {delimiter:self.settings.delimiter} as RecursivePartial<TomSettings> ) : self.settings;
+		const settings	= get_settings ? getSettings( self.input, {delimiter:self.settings.delimiter,allowEmptyOption:self.settings.allowEmptyOption} as RecursivePartial<TomSettings> ) : self.settings;
 
 		self.setupOptions(settings.options,settings.optgroups);
 

--- a/test/support/base.js
+++ b/test/support/base.js
@@ -37,6 +37,7 @@ var teardownLast = function(){
 var test_html = {
 	AB_Multi			: '<select multiple><option value="a">a</option><option value="b">b</option><option value="c">c</option></select>',
 	AB_Single			: '<select><option value="a">a</option><option value="b">b</option><option value="c">c</option></select>',
+	AB_Single_Empty		: '<select><option value="">empty</option><option value="a">a</option><option value="b">b</option><option value="c">c</option></select>',
 	AB_Single_Long		: '<select><option>a</option><option>b</option><option>c</option><option>d</option><option>e</option><option>f</option><option>g</option><option>h</option><option>i</option><option>j</option><option>k</option><option>l</option><option>m</option><option>n</option><option>o</option><option>p</option></select>',
 }
 

--- a/test/tests/api.js
+++ b/test/tests/api.js
@@ -1007,5 +1007,14 @@
 				assert.equal(test.instance.items.length, 1,'should have one item');
 				assert.equal(test.instance.items[0], 'new');
 			});
+
+			it_n('sync() should retain empty value',function(){
+				const test		= setup_test('AB_Single_Empty',{allowEmptyOption:true});
+				var opt_count	= Object.keys(test.instance.options).length;
+				test.instance.sync(true);
+
+				assert.equal(test.instance.items[0], '', 'empty item should remain');
+				assert.equal( Object.keys(test.instance.options).length, opt_count, 'option count remains');
+			});
 		});
 	});


### PR DESCRIPTION
Fixes #783 

When `sync(true)` is called. The `allowEmptyOption` setting should remain. Thus allowing the empty `<option>` label to remain in the ts-control.