### PR TITLE
Add option for dynamic Optgroup creation

### DIFF
--- a/doc_src/pages/docs/index.md
+++ b/doc_src/pages/docs/index.md
@@ -346,6 +346,32 @@ tom.inputState();
 		<td><code>'optgroup'</code></td>
 	</tr>
 	<tr>
+		<td><code>optionGroupRegister</td>
+		<td>A function to transform and manage non existent Optgroups (f.e. for remote data)
+
+```js
+optionGroupRegister: function (optgroup) {}
+```
+
+You can style the Optgroup like normal configuration. Here for example the first letter will capitalized and used as Optgroup name.
+
+```js
+optionGroupRegister: function (optgroup) {
+        var capitalised = optgroup.charAt(0).toUpperCase() + optgroup.substring(1);
+        var group = {
+          label: capitalised
+        };
+
+        group[this.settings.optgroupValueField] = optgroup;
+
+        return group;
+      },
+```
+</td>
+		<td><code>function</code></td>
+		<td><code>null</code></td>
+	</tr>
+	<tr>
 		<td><code>disabledField</code></td>
 		<td>The name of the property to disabled option and optgroup.</td>
 		<td><code>string</code></td>

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1463,6 +1463,13 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 				let order = option.$order;
 				let self_optgroup = self.optgroups[optgroup];
+				if (self_optgroup === undefined && typeof self.settings.optionGroupRegister === 'function') {
+	          		var regGroup;
+					if (regGroup = self.settings.optionGroupRegister.apply(self, [optgroup])) {
+						self.registerOptionGroup(regGroup);
+					}
+	        	}
+				self_optgroup = self.optgroups[optgroup];
 				if( self_optgroup === undefined ){					
 					optgroup = '';
 				}else{

--- a/test/tests/setup.js
+++ b/test/tests/setup.js
@@ -185,6 +185,44 @@
 				}, '2');
 			});
 
+			it_n('should register should not care optionGroupRegister is not set', function () {
+        		var test = setup_test('<select>', {
+	          		options: [
+	            		{ value: 'a', grp: 'someGroup' },
+	            		{ value: 'b', grp: 'anotherGroup' },
+	            		{ value: 'c', grp: 'anotherGroup' }
+	          		],
+	          		optgroupValueField: 'val',
+	          		optgroupField: 'grp',
+        		});
+        		test.instance.refreshOptions();
+        		assert.deepEqual(test.instance.optgroups, {}, '2');
+      		});
+
+			it_n('should register optgroups if optionGroupRegister is set', function () {
+        		var test = setup_test('<select>', {
+			        options: [
+			        	{ value: 'a', grp: 'someGroup' },
+			            { value: 'b', grp: 'anotherGroup' },
+			            { value: 'c', grp: 'anotherGroup' }
+			        ],
+	          		optgroupValueField: 'val',
+	          		optgroupField: 'grp',
+	          		optionGroupRegister: function (optgroup) {
+	            		var group = {};
+	            		group['label'] = optgroup;
+	            		group['val'] = optgroup;
+	
+	            		return group;
+	          		}
+        		});
+	        test.instance.refreshOptions(true);
+        	assert.deepEqual(test.instance.optgroups, {
+          			'someGroup': { label: 'someGroup', val: 'someGroup', $order: 4 },
+          			'anotherGroup': { label: 'anotherGroup', val: 'anotherGroup', $order: 5 }
+        		}, '2');
+     	 	});
+
 			it_n('should render optgroups with duplicated options correctly', function(done) {
 				var test = setup_test(['<select>',
 					'<optgroup label="Group 1">',


### PR DESCRIPTION
With this PR you can create Optgroups dynamicaly for example when you only use remote data. If the new functions isn't declared, the old handling will take place.