### PR TITLE
Disable AppArmor in CI for headless Chrome

### DIFF
--- a/.config/karma.conf.cjs
+++ b/.config/karma.conf.cjs
@@ -102,7 +102,9 @@ module.exports = function(config) {
 										flags: [
 											'--disable-translate',
 											'--disable-extensions',
-											'--remote-debugging-port=9223'
+											'--remote-debugging-port=9223',
+											// Needed to run on Ubuntu 24.04 in GitHub Actions.
+											'--no-sandbox'
 										]
 									};
 	}

--- a/.config/karma.conf.cjs
+++ b/.config/karma.conf.cjs
@@ -103,8 +103,6 @@ module.exports = function(config) {
 											'--disable-translate',
 											'--disable-extensions',
 											'--remote-debugging-port=9223',
-											// Needed to run on Ubuntu 24.04 in GitHub Actions.
-											'--no-sandbox'
 										]
 									};
 	}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      # This is needed to run headless Chrome on Ubuntu 24.04.
+      - name: Disable AppArmor
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - run: npm ci
       - run: npm run build
       - run: npm run build:docs


### PR DESCRIPTION
Recent CI runs have failed with the following:

```
27 01 2025 12:37:09.075:INFO [launcher]: Starting browser ChromeHeadless
27 01 2025 12:37:09.420:ERROR [launcher]: Cannot start ChromeHeadless
	[2162:2162:0127/123709.126845:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0127/123709.[13](https://github.com/orchidjs/tom-select/actions/runs/12989117337/job/36221505850?pr=872#step:7:14)4265:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0127/123709.134304:ERROR:file_io_posix.cc([14](https://github.com/orchidjs/tom-select/actions/runs/12989117337/job/36221505850?pr=872#step:7:15)5)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```

I believe this is because CI is now running with Ubuntu 24.04. As recommended on https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md, we'll disable AppArmor.