### PR TITLE
fix scroll issue with checkbox plugin when query has content

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -17,6 +17,7 @@ export default {
 	maxOptions: 50,
 	maxItems: null,
 	hideSelected: null,
+	clearSearchOnChange: true,
 	duplicates: false,
 	addPrecedence: false,
 	selectOnTab: false,

--- a/src/plugins/checkbox_options/plugin.ts
+++ b/src/plugins/checkbox_options/plugin.ts
@@ -25,6 +25,7 @@ export default function(this:TomSelect, userOptions:CBOptions) {
 	var orig_onOptionSelect = self.onOptionSelect;
 
 	self.settings.hideSelected = false;
+	self.settings.clearSearchOnChange = false;
 
 	const cbOptions : CBOptions = Object.assign({
 		// so that the user may add different ones as well

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -891,7 +891,9 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		} else {
 			value = option.dataset.value;
 			if (typeof value !== 'undefined') {
-				self.lastQuery = null;
+				if (this.settings.clearSearchOnChange) {
+					self.lastQuery = null;
+				}
 				self.addItem(value);
 				if (self.settings.closeAfterSelect) {
 					self.close();
@@ -2042,7 +2044,9 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		}
 
 		self.items.splice(i, 1);
-		self.lastQuery = null;
+		if (this.settings.clearSearchOnChange) {
+			self.lastQuery = null;
+		}
 		if (!self.settings.persist && self.userOptions.hasOwnProperty(value)) {
 			self.removeOption(value, silent);
 		}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -25,6 +25,7 @@ export type TomSettings = {
 	maxOptions				: number,
 	maxItems				: null|number,
 	hideSelected			: boolean,
+	clearSearchOnChange     : boolean,
 	duplicates				: boolean,
 	addPrecedence			: boolean,
 	selectOnTab				: boolean,


### PR DESCRIPTION
This is to fix a scroll issue with checkbox_options plugin.

Steps to reproduce the issue:

1 - have a multi-select with checkbox_options plugin enabled with enough options that it is still scrollable with something typed in the search box.
2 - open the select, type a query with partial match that matches enough options to allow scrolling.
3 - scroll to bottom of the list
4 - mark 2 checkboxes

problem:
after selecting the second option the list scrolls to the top making it cumbersome to select near options.

expected behaviour (fixed with this PR):
Checkbox to be marked and selection to stay visible so we can continue selecting further records.