### PR TITLE
Use multiplication sign as clear icon

### DIFF
--- a/src/plugins/clear_button/plugin.ts
+++ b/src/plugins/clear_button/plugin.ts
@@ -24,7 +24,7 @@ export default function(this:TomSelect, userOptions:CBOptions) {
 		className: 'clear-button',
 		title: 'Clear All',
 		html: (data:CBOptions) => {
-			return `<div class="${data.className}" title="${data.title}">&#10799;</div>`;
+			return `<div class="${data.className}" title="${data.title}">&times;</div>`;
 		}
 	}, userOptions);
 


### PR DESCRIPTION
The clear button plugin uses the Unicode character U+2A2F (VECTOR OR CROSS PRODUCT) as the close icon, while U+00D7 (MULTIPLICATION SIGN) is used to deselected items.

Here are the two unicode characters:
⨯ ×

The difference between these two characters is the vertical alignment and that U+2A2F is rarely part of a font file. In these cases, a fallback font is used (in my case Apple Symbols), which then also differs from the original font in terms of stroke width.

Closes https://github.com/orchidjs/tom-select/issues/901
