### PR TITLE
Fix BS5 form-select-sm padding-bottom

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -163,7 +163,6 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 		&.has-items .#{$select-ns}-control {
 			font-size: $input-font-size-sm;
-			padding-bottom: 0;
 		}
 	}
 

--- a/test/html/bootstrap5.html
+++ b/test/html/bootstrap5.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<head>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css">
+	<link rel="stylesheet" href="../../dist/css/tom-select.bootstrap5.css">
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
+	<script src="../../dist/js/tom-select.complete.js"></script>
+</head>
+<body class="p-4">
+<h3>form-select</h3>
+<select class="form-select ts">
+	<option value="1">Option 1</option>
+	<option value="2">Option 2</option>
+	<option value="3">Option 3</option>
+	<option value="4">Option 4</option>
+</select>
+
+<hr/>
+
+<h3>form-select-sm</h3>
+<select class="form-select form-select-sm ts">
+	<option value="1">Option 1</option>
+	<option value="2">Option 2</option>
+	<option value="3">Option 3</option>
+	<option value="4">Option 4</option>
+</select>
+
+<hr/>
+
+<h3>form-select-lg</h3>
+<select class="form-select form-select-lg ts">
+	<option value="1">Option 1</option>
+	<option value="2">Option 2</option>
+	<option value="3">Option 3</option>
+	<option value="4">Option 4</option>
+</select>
+<script>
+	document.querySelectorAll('.ts').forEach(function (select) {
+		new TomSelect(select, {
+			persist: false,
+			createOnBlur: true,
+			create: false
+		});
+	});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixing padding for Bootstrap 5 form-select-sm.

## Before

![image](https://github.com/user-attachments/assets/63e18a87-a1d6-4dcd-815d-fc1a9af422bb)

## After

![image](https://github.com/user-attachments/assets/56c7af17-6a60-4d8b-b301-1022cacadd56)
