### PR TITLE
Allow `TomSettings.maxOptions` to be null

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -22,7 +22,7 @@ export type TomSettings = {
 	highlight				: boolean,
 	openOnFocus				: boolean,
 	shouldOpen				: boolean,
-	maxOptions				: number,
+	maxOptions				: null|number,
 	maxItems				: null|number,
 	hideSelected			: boolean,
 	duplicates				: boolean,


### PR DESCRIPTION
Per the docs, this value can be set to `null`.
https://github.com/orchidjs/tom-select/blob/4522c18a0236061d6af19475e202a796f4a35a99/doc_src/pages/docs/index.md?plain=1#L172-L173