### PR TITLE
copy aria-label from control input

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -196,7 +196,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			control_input		= getDom(settings.controlInput ) as HTMLInputElement;
 
 			// set attributes
-			var attrs = ['autocorrect','autocapitalize','autocomplete','spellcheck'];
+			var attrs = ['autocorrect','autocapitalize','autocomplete','spellcheck','aria-label'];
 			iterate(attrs,(attr:string) => {
 				if( input.getAttribute(attr) ){
 					setAttr(control_input,{[attr]:input.getAttribute(attr)});


### PR DESCRIPTION
This PR adds the attribute `aria-label` to the list of attributes to copy from the control input.

Fixes #908 