### PR TITLE
Refactor padding calculations to use unquote for better compatibility

### DIFF
--- a/src/plugins/clear_button/plugin.scss
+++ b/src/plugins/clear_button/plugin.scss
@@ -19,10 +19,10 @@
 	&.single .clear-button {
 
 		@if variable-exists(select-padding-dropdown-item-x) {
-			right: Max(var(--ts-pr-caret), #{$select-padding-dropdown-item-x});
+			right: unquote('max(var(--ts-pr-caret), #{$select-padding-dropdown-item-x})');
 		}
 		@else{
-			right: Max(var(--ts-pr-caret), calc(#{$select-padding-x} - #{$select-padding-item-x}));
+			right: unquote('max(var(--ts-pr-caret), calc(#{$select-padding-x} - #{$select-padding-item-x}))');
 		}
 	}
 

--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -101,11 +101,11 @@ $select-spinner-border-color:					$select-color-border !default;
 }
 
 .#{$select-ns}-control:not(.rtl) {
-	padding-right:	max( var(--ts-pr-min), calc( var(--ts-pr-clear-button) + var(--ts-pr-caret)) ) !important;
+    padding-right: unquote('max(var(--ts-pr-min), calc(var(--ts-pr-clear-button) + var(--ts-pr-caret)))') !important;
 }
 
 .#{$select-ns}-control.rtl {
-	padding-left:	max( var(--ts-pr-min), calc( var(--ts-pr-clear-button) + var(--ts-pr-caret)) ) !important;
+    padding-left: unquote('max(var(--ts-pr-min), calc(var(--ts-pr-clear-button) + var(--ts-pr-caret)))') !important;
 }
 
 @mixin ts-caret() {
@@ -125,11 +125,11 @@ $select-spinner-border-color:					$select-color-border !default;
 				border-width: $select-arrow-size $select-arrow-size 0 $select-arrow-size;
 				border-color: $select-arrow-color transparent transparent transparent;
 			}
-			
+
 			&:not(.rtl)::after {
 				right: $select-arrow-offset;
 			}
-			
+
 			&.rtl::after {
 				left: $select-arrow-offset;
 			}


### PR DESCRIPTION
## Motivation

when I use Ruby on Rails 7 and sass-rails 6.0.0 gem I have error SassC::SyntaxError

Expected SassC::SyntaxError when compiling max(var(...)) as SCSS

for example style that lead to error

```
.style-name {
        right: max(var(--ts-pr-caret), 8px);
      }
```

style that not lead to error

```
.style-name {
        right: unquote('max(var(--ts-pr-caret), 8px)');
      }
```