### PR TITLE
Add minWidth and maxWidth to wrapper style

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -269,6 +269,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		}
 
 		wrapper.style.width = input.style.width;
+        wrapper.style.minWidth = input.style.minWidth;
+        wrapper.style.maxWidth = input.style.maxWidth;
 
 		if (self.plugins.names.length) {
 			const classes_plugins = 'plugin-' + self.plugins.names.join(' plugin-');


### PR DESCRIPTION
I would like to suggest applying min and max width in addition to the width.
In my project, we use auto width by default on all select and sometime we need to specify a `min-width` (eg: to prevent the placeholder to be truncated)