### PR TITLE
ci: add publishing workflow

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,0 +1,27 @@
+name: publish
+on:
+ release:
+   types: [created]
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish latest release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: npm ci
+      - name: Build dist files
+        run: npm run build
+      - name: Publish
+        run: npm publish


### PR DESCRIPTION
@oyejorge

Could you please configure NPM to allow publishing with OIDC from that file? (or give me npm package write access).

This workflow is great because it doesn't involve any token :)

https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/

It's super easy to configure on npm website, go to the settings page and configure the file "publishing.yml" as a workflow file.