### PR TITLE
fix #818 - Change config param name from 'html' to 'text'

### DIFF
--- a/doc_src/pages/plugins/restore-on-backspace.njk
+++ b/doc_src/pages/plugins/restore-on-backspace.njk
@@ -37,7 +37,7 @@ new TomSelect('#input-tags6',{
 
 {{ config_table([
 		{
-			name:'html',
+			name:'text',
 			desc:'<p>A function taking option data as an argument and returning a text string that will be assigned to the control input value</p>',
 			type:'callback',
 			default:'function(option){\n		return option[self.settings.labelField];\n}',


### PR DESCRIPTION
Fix wrong parameter name on docu.

This PR fixes #818
