### PR TITLE
fix: add this context to onDelete callback

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2459,7 +2459,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		const values = items.map(item => item.dataset.value);
 
 		// allow the callback to abort
-		if( !values.length || (typeof this.settings.onDelete === 'function' && this.settings.onDelete(values,evt) === false) ){
+		if( !values.length || (typeof this.settings.onDelete === 'function' && this.settings.onDelete.call(this,values,evt) === false) ){
 			return false;
 		}
 

--- a/test/tests/plugins/remove_button.js
+++ b/test/tests/plugins/remove_button.js
@@ -123,4 +123,36 @@ describe('plugin: remove_button', function() {
 		await waitFor(100);
 		assert.equal( test.instance.items.length, 2 );
 	});
+
+	it_n('onDelete should be called with correct context (this)', async () => {
+		let contextCheck = null;
+		let apiCheck = null;
+
+		let test = setup_test('AB_Multi', {
+			onDelete: function(values, evt) {
+				contextCheck = this;
+				// Verify 'this' has access to TomSelect API methods
+				apiCheck = typeof this.getValue === 'function' &&
+					typeof this.addItem === 'function' &&
+					typeof this.removeItem === 'function';
+				return true; // allow deletion
+			}
+		});
+
+		test.instance.addItem('a');
+		test.instance.addItem('b');
+		assert.equal(test.instance.items.length, 2);
+
+		// Trigger deletion by setting active item and pressing backspace
+		test.instance.setActiveItem(test.instance.getItem('b'));
+		assert.equal(test.instance.activeItems.length, 1);
+
+		await asyncType('\b', test.instance.control_input);
+		await waitFor(10);
+
+		// Verify the callback was called and had correct context
+		assert.equal(contextCheck, test.instance, 'onDelete should have TomSelect instance as context');
+		assert.isTrue(apiCheck, 'onDelete should have access to TomSelect API methods');
+		assert.equal(test.instance.items.length, 1, 'item should be deleted');
+	});
 });


### PR DESCRIPTION
<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->

The `onDelete` callback doesn't bind `this` so you can't access any of the API functions:
```js
                 onDelete: function (input) {
                    var self = this;
                    $.each(input, function (key, value) {
                        // Delete any items selected that don't have a 'unremovable' class.
                        if (!$('.cc-emails div[data-value="' + value + '"]').hasClass('unremovable')) {
                            self.removeItem(value);
                            self.removeOption(value);
                        }
                    });

                    // We handle the deletions above, no need to carry on with deleteSelect()
                    return false;
                }
```