### PR TITLE
prevent UI crash

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1365,10 +1365,9 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// temp fix for https://github.com/orchidjs/tom-select/issues/987
 			// UI crashed when more than 30 same chars in a row, prevent search and return empt result
 			if (/(.)\1{15,}/.test(query)) {
-				result 				= { items: [], total: 0 } as PrepareObj;
-			} else {
-				result 				= self.sifter.search(query, Object.assign(options, { score: calculateScore }));
+				query 				= '';
 			}
+			result 					= self.sifter.search(query, Object.assign(options, { score: calculateScore }));
 			self.currentResults		= result;
 		} else {
 			result					= Object.assign( {}, self.currentResults);


### PR DESCRIPTION
This fix checks whether the search query contains more than 15 identical characters in a row. If this is the case, the search is canceled and an empty result is returned.

fixes #987 
fixes #745 
