### PR TITLE
fix sass deprecations

### DIFF
--- a/doc_src/css/variables.scss
+++ b/doc_src/css/variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // colors
 $min-contrast-ratio: 1.5 !default;
 $text-muted-opacity: .7 !default;
@@ -76,8 +78,8 @@ $danger: $red !default;
 
 
 // Dark mode
-$dark-mode-darken: darken($dark, 2%) !default;
-$dark-mode-lighten: lighten($dark, 2%) !default;
+$dark-mode-darken: color.adjust($dark, $lightness: -2%) !default;
+$dark-mode-lighten: color.adjust($dark, $lightness: 2%) !default;
 $dark-mode-text: $light;
 
 // Borders

--- a/src/plugins/clear_button/plugin.scss
+++ b/src/plugins/clear_button/plugin.scss
@@ -1,4 +1,5 @@
 /* stylelint-disable function-name-case */
+@use "sass:meta";
 
 .plugin-clear_button {
 	--ts-pr-clear-button: 1em;
@@ -18,7 +19,7 @@
 	&.form-select .clear-button,
 	&.single .clear-button {
 
-		@if variable-exists(select-padding-dropdown-item-x) {
+		@if meta.variable-exists("select-padding-dropdown-item-x") {
 			right: Max(var(--ts-pr-caret), #{$select-padding-dropdown-item-x});
 		}
 		@else{

--- a/src/plugins/dropdown_header/plugin.scss
+++ b/src/plugins/dropdown_header/plugin.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 .#{$select-ns}-wrapper{
 	.dropdown-header {
 		position: relative;
@@ -19,6 +21,6 @@
 	}
 
 	.dropdown-header-close:hover {
-		color: darken($select-color-text, 25%);
+		color: color.adjust($select-color-text, $lightness: -25%)
 	}
 }

--- a/src/plugins/dropdown_input/plugin.scss
+++ b/src/plugins/dropdown_input/plugin.scss
@@ -1,9 +1,11 @@
+@use "sass:meta";
+
 .plugin-dropdown_input{
 
 	&.focus.dropdown-active .#{$select-ns}-control{
 		box-shadow: none;
 		border: $select-border;
-		@if variable-exists(input-box-shadow) {
+		@if meta.variable-exists("input-box-shadow") {
 			box-shadow: $input-box-shadow;
 		}
 	}
@@ -19,7 +21,7 @@
 	}
 
 	&.focus .#{$select-ns}-dropdown .dropdown-input{
-		@if variable-exists(input-focus-border-color) {
+		@if meta.variable-exists("input-focus-border-color") {
 			border-color: $input-focus-border-color;
 			outline: 0;
 			@if $enable-shadows {

--- a/src/plugins/remove_button/plugin.scss
+++ b/src/plugins/remove_button/plugin.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 .#{$select-ns}-wrapper.plugin-remove_button{
 	.item {
 		display: inline-flex;
@@ -46,7 +48,7 @@
 	}
 
 	&.disabled .item .remove {
-		border-left-color: lighten(desaturate($select-color-item-border, 100%), $select-lighten-disabled-item-border);
+		border-left-color: color.adjust($select-color-item-border, $saturation: -100%, $lightness: $select-lighten-disabled-item-border);
 	}
 }
 
@@ -65,6 +67,6 @@
 	}
 
 	&.disabled .item .remove {
-		border-right-color: lighten(desaturate($select-color-item-border, 100%), $select-lighten-disabled-item-border);
+		border-right-color: color.adjust($select-color-item-border, $saturation: -100%, $lightness: $select-lighten-disabled-item-border);
 	}
 }

--- a/src/scss/_items.scss
+++ b/src/scss/_items.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 .#{$select-ns}-control {
 	border: $select-border;
 	padding: $select-padding-y $select-padding-x;
@@ -55,9 +57,10 @@
 
 	.#{$select-ns}-wrapper.multi.disabled & > div {
 		&, &.active {
-			color: lighten(desaturate($select-color-item-text, 100%), $select-lighten-disabled-item-text);
-			background: lighten(desaturate($select-color-item, 100%), $select-lighten-disabled-item);
-			border: $select-width-item-border solid lighten(desaturate($select-color-item-border, 100%), $select-lighten-disabled-item-border);
+			color: color.adjust($select-color-item-text, $saturation: -100%, $lightness: $select-lighten-disabled-item-text);
+			background: color.adjust($select-color-item, $saturation: -100%, $lightness: $select-lighten-disabled-item);
+			border: $select-width-item-border solid color.adjust($select-color-item-border, $saturation: -100%, $lightness: $select-lighten-disabled-item-border);
+			
 		}
 	}
 

--- a/src/scss/tom-select.bootstrap4.scss
+++ b/src/scss/tom-select.bootstrap4.scss
@@ -2,6 +2,8 @@
  * Tom Select Bootstrap 4
  */
 
+@use "sass:color";
+
 // Import Bootstrap 4 functions and variables
 $state-valid: map-get($form-validation-states,'valid') !default;
 $state-invalid: map-get($form-validation-states,'invalid') !default;
@@ -15,7 +17,7 @@ $select-color-highlight: rgba(255, 237, 40, 40%) !default;
 $select-color-input: $input-bg !default;
 $select-color-input-full: $input-bg !default;
 $select-color-input-error: map-get($state-invalid,'color') !default;
-$select-color-input-error-focus: darken($select-color-input-error, 10%) !default;
+$select-color-input-error-focus: color.adjust($select-color-input-error, $lightness: -10%) !default; 
 $select-color-disabled: $input-disabled-bg !default;
 $select-color-item: #efefef !default;
 $select-color-item-border: $border-color !default;
@@ -97,11 +99,11 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 .#{$select-ns}-control {
 	min-height: $input-height;
-	@include box-shadow($input-box-shadow);
-	@include transition($input-transition);
-
 	display:flex;
 	align-items: center;
+
+	@include box-shadow($input-box-shadow);
+	@include transition($input-transition);
 
 	.focus & {
 		border-color: $input-focus-border-color;

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -122,11 +122,11 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 }
 
 .#{$select-ns}-control {
-	@include box-shadow($input-box-shadow);
-	@include transition($input-transition);
-
 	display:flex;
 	align-items: center;
+
+	@include box-shadow($input-box-shadow);
+	@include transition($input-transition);
 
 	.focus & {
 		border-color: $input-focus-border-color;

--- a/src/scss/tom-select.scss
+++ b/src/scss/tom-select.scss
@@ -13,6 +13,9 @@
  *
  */
 
+@use "sass:color";
+@use "sass:math";
+
 // base styles
 $select-ns:										'ts' !default;
 $select-font-family:							inherit !default;
@@ -35,7 +38,7 @@ $select-color-dropdown-border:					$select-color-border !default;
 $select-color-dropdown-border-top:				#f0f0f0 !default;
 $select-color-dropdown-item-active:				#f5fafd !default;
 $select-color-dropdown-item-active-text:		#495c68 !default;
-$select-color-dropdown-item-create-text:		rgba(red($select-color-text), green($select-color-text), blue($select-color-text), 50%) !default;
+$select-color-dropdown-item-create-text:		color.change($select-color-text, $alpha: 0.5) !default;
 $select-color-dropdown-item-create-active-text:	$select-color-dropdown-item-active-text !default;
 $select-color-optgroup:							$select-color-dropdown !default;
 $select-color-optgroup-text:					$select-color-text !default;
@@ -118,7 +121,7 @@ $select-spinner-border-color:					$select-color-border !default;
 				display: block;
 				position: absolute;
 				top: 50%;
-				margin-top: round(-0.5 * $select-arrow-size);
+				margin-top: math.round(-0.5 * $select-arrow-size);
 				width: 0;
 				height: 0;
 				border-style: solid;


### PR DESCRIPTION
With this PR we will make tom-select sass 3.0 ready. So we need to solve all deprecated functions.

Already inclueded:
- remove al deprecated features/methods

Need to do:
- switch vom @import to @use 

fixes #911 