### PR TITLE
bug/minor: fix hideSelected not working with allowEmptyOption for empty value options

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1377,7 +1377,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		if( self.settings.hideSelected ){
 			result.items = result.items.filter((item) => {
 				let hashed = hash_key(item.id);
-				return !(hashed && self.items.indexOf(hashed) !== -1 );
+				return !(hashed !== null && self.items.indexOf(hashed) !== -1 );
 			});
 		}
 

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -120,4 +120,25 @@ describe('Configuration settings', function() {
 		assert.equal( test.instance.items.length, 1);
 	});
 
+	it_n('allowEmptyOption + hideSelected should hide selected empty option', async () => {
+
+		let test = setup_test(`<select multiple>
+				<option value="">None</option>
+				<option value="1">Option 1</option>
+				<option value="2">Option 2</option>
+			</select>`, {allowEmptyOption:true});
+
+		assert.isTrue(test.instance.settings.hideSelected);
+
+		await asyncClick(test.instance.control);
+		var opt = test.instance.getOption('');
+		assert.isNotNull(opt, 'empty option should exist before selection');
+		await asyncClick(opt);
+		assert.equal(test.instance.items.length, 1);
+
+		await asyncClick(test.instance.control);
+		var optAfter = test.instance.dropdown_content.querySelector('[data-value=""]');
+		assert.isNull(optAfter, 'empty option should be hidden after selection');
+	});
+
 });


### PR DESCRIPTION
https://github.com/orchidjs/tom-select/issues/930

Empty string values were treated as falsy in the hideSelected filter, causing options with value="" to remain visible in the dropdown after selection.

## Bug

In multi-select mode with `allowEmptyOption: true`, options with empty values (`value=""`) are not hidden from the dropdown after being selected, despite `hideSelected` being enabled by default.

## Cause

In the `hideSelected` filter logic 
https://github.com/orchidjs/tom-select/blob/81eda24435d5931607dd27d8f17a91da53f64d88/src/tom-select.ts#L1377-L1382

the condition `hashed && ...` treats empty string as falsy, so `hash_key("")` (`""`) always passes through the filter.

## Fix

Changed `hashed &&` to `hashed !== null &&` so that only `null` (from `undefined`/`null` input) is excluded, and empty string `""` is correctly filtered as a selected item.
