### PR TITLE
Try update when option already exist

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1662,7 +1662,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		const key = hash_key(data[self.settings.valueField]);
 		if( key === null || self.options.hasOwnProperty(key) ){
-			return self.updateOption(data[self.settings.labelField], data);
+			self.updateOption(data[self.settings.labelField], data);
+			return false;
 		}
 
 		data.$order			= data.$order || ++self.order;

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1662,7 +1662,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		const key = hash_key(data[self.settings.valueField]);
 		if( key === null || self.options.hasOwnProperty(key) ){
-			self.updateOption(data[self.settings.labelField], data);
+			self.updateOption(data[self.settings.valueField], data);
 			return false;
 		}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1662,7 +1662,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		const key = hash_key(data[self.settings.valueField]);
 		if( key === null || self.options.hasOwnProperty(key) ){
-			return false;
+			return self.updateOption(data[self.settings.labelField], data);
 		}
 
 		data.$order			= data.$order || ++self.order;

--- a/test/tests/api.js
+++ b/test/tests/api.js
@@ -341,6 +341,9 @@
 				test.instance.addOption({value: 'a', test: 'hello'});
 				expect(test.instance.options.a).to.have.property('test');
 			});
+			it_n('should be false when value is missing (null)', function() {
+				expect(test.instance.addOption({value: null})).to.be.equal(false);
+			});
 		});
 
 		describe('addItem()', function() {

--- a/test/tests/api.js
+++ b/test/tests/api.js
@@ -336,10 +336,10 @@
 				expect(test.instance.options).to.have.property('a');
 				expect(test.instance.options).to.have.property('b');
 			});
-			it_n('should not override existing options', function() {
+			it_n('should update existing option when adding new one', function() {
 				test.instance.addOption([{value: 'a'}, {value: 'b'}]);
 				test.instance.addOption({value: 'a', test: 'hello'});
-				expect(test.instance.options.a).to.not.have.property('test');
+				expect(test.instance.options.a).to.have.property('test');
 			});
 		});
 


### PR DESCRIPTION
fixes #854 
fixes #859 
fixes #990 

This PR executes the updateOption method when the àddOption` method detects, that the 'new' option already exists.