### PR TITLE
add null as valid controlInput

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -61,7 +61,7 @@ export type TomSettings = {
 	optionClass				: string,
 
 	dropdownParent			: string,
-	controlInput			: string|HTMLInputElement,
+	controlInput			: null|string|HTMLInputElement,
 
 	copyClassesToDropdown	: boolean,
 


### PR DESCRIPTION
Adding `null` as valid `controlInput` - there is a fallback implemnented, when no valid HTML oder string is given, then the fallback is acting.

fixes #893