### PR TITLE
Clear input before refreshing options

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2006,6 +2006,11 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 						self.setActiveOption(next);
 					}
 				}
+				
+				//remove input value when enabled
+				if(self.settings.clearAfterSelect) {
+					self.setTextboxValue();
+				}
 
 				// refreshOptions after setActiveOption(),
 				// otherwise setActiveOption() will be called by refreshOptions() with the wrong value
@@ -2018,11 +2023,6 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 					self.close();
 				} else if (!self.isPending) {
 					self.positionDropdown();
-				}
-				
-				//remove input value when enabled
-				if(self.settings.clearAfterSelect) {
-					self.setTextboxValue();
 				}
 
 				self.trigger('item_add', hashed, item);


### PR DESCRIPTION
Just moving the recently added code related to `clearAfterSelect` option before calling `refreshOptions()` so that the dropdown is properly refreshed instead of showing an empty option list.