### PR TITLE
Fix virtual_scroll losing preloaded options after search

### DIFF
--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -193,9 +193,13 @@ export default function(this:TomSelect) {
 
 	// Restore preloaded options and pagination when clearing search
 	const restoreDefaults = ():void => {
-		if( !default_values_loaded ) return;
+		if( !default_values_loaded ) {
+			return;
+		}
 		self.clearOptions(clearFilter);
-		if( default_pagination ) pagination[''] = default_pagination;
+		if( default_pagination ) {
+			pagination[''] = default_pagination;
+		}
 	};
 
 	self.on('type',(query:string) => {


### PR DESCRIPTION
## Problem

When using `virtual_scroll` with `preload: true`, searching and then clearing the search (or closing the dropdown) causes two issues:

1. **Preloaded options disappear** — `default_values` is set on `initialize` before `preload` fires, so it only captures HTML `<option>` elements. When `clearOptions(clearFilter)` runs during a subsequent search, all preloaded options are discarded because they aren't in `default_values`.

2. **Virtual scroll stops working** — The pagination state for the empty query (`""`) is lost when `getUrl()` calls `clearPagination()` for a new search query. After clearing the search, scrolling no longer triggers loading of additional pages.

The result is that after searching and clearing, the dropdown shows a mix of stale search results and the original HTML options, with no ability to scroll-load more.

## Demo

### Before

https://github.com/user-attachments/assets/84018f63-e7d2-4b20-9e9c-658ef0e5277e

### After

https://github.com/user-attachments/assets/015d995f-b069-45ed-b8f9-0b7cc92ce013


## Fix

Two changes to the `virtual_scroll` plugin:

1. **Update `default_values` after the first `loadCallback`** — so preloaded options are preserved through `clearOptions(clearFilter)` calls, not just the HTML `<option>` elements.

2. **Save and restore empty-query pagination** — capture `pagination['']` after the first load, and restore it when the search is cleared (`type('')`) or the dropdown closes (`dropdown_close`), so virtual scroll continues to work.

Both changes are guarded by a `default_values_loaded` flag, so they are no-ops until the first load completes, and work correctly whether or not `preload` is used.