### PR TITLE
move state check to inputState() method

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -419,14 +419,6 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		self.inputState();
 		self.isSetup = true;
 
-		if( input.disabled ){
-			self.disable();
-		}else if( input.readOnly ){
-			self.setReadOnly(true);
-		}else{
-			self.enable(); //sets tabIndex
-		}
-
 		self.on('change', this.onChange);
 
 		addClasses(input,'tomselected','ts-hidden-accessible');
@@ -1246,7 +1238,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	}
 
 	/**
-	 * Determines if the control_input should be in a hidden or visible state
+	 * Determines if the control_input should be in a hidden or visible state and check if it's disabled/readOnly
 	 *
 	 */
 	inputState(){
@@ -1266,6 +1258,14 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 				setAttr(self.control_input,{placeholder:''});
 			}
 			self.isInputHidden = false;
+		}
+
+		if( self.input.disabled ){
+			self.disable();
+		}else if( self.input.readOnly ){
+			self.setReadOnly(true);
+		}else{
+			self.enable(); //sets tabIndex
 		}
 
 		self.wrapper.classList.toggle('input-hidden', self.isInputHidden );

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -539,6 +539,14 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		self.setValue(settings.items||[],true); // silent prevents recursion
 
+		if( self.input.disabled ){
+			self.disable();
+		}else if( self.input.readOnly ){
+			self.setReadOnly(true);
+		}else{
+			self.enable(); //sets tabIndex
+		}
+
 		self.lastQuery = null; // so updated options will be displayed in dropdown
 	}
 
@@ -1238,7 +1246,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	}
 
 	/**
-	 * Determines if the control_input should be in a hidden or visible state and check if it's disabled/readOnly
+	 * Determines if the control_input should be in a hidden or visible state
 	 *
 	 */
 	inputState(){
@@ -1258,14 +1266,6 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 				setAttr(self.control_input,{placeholder:''});
 			}
 			self.isInputHidden = false;
-		}
-
-		if( self.input.disabled ){
-			self.disable();
-		}else if( self.input.readOnly ){
-			self.setReadOnly(true);
-		}else{
-			self.enable(); //sets tabIndex
 		}
 
 		self.wrapper.classList.toggle('input-hidden', self.isInputHidden );


### PR DESCRIPTION
At the moment, the check if the original select element is disabled or readonly will performend only on `setup()` method. With this change we move the part to the `ìnputState()` method, where the control_input is checked and modified. This will be called also on `sync()` - so the new state of the original select will be considered.

Fixes #990 