### PR TITLE
Avoid stealing focus if moved before onFocus

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1287,15 +1287,18 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		self.ignoreFocus = true;
 
-		if( self.control_input.offsetWidth ){
-			self.control_input.focus();
-		}else{
-			self.focus_node.focus();
-		}
+		const focusTarget = this.control_input.offsetWidth ? this.control_input : this.focus_node;
+    	focusTarget.focus();
 
 		setTimeout(() => {
 			self.ignoreFocus = false;
-			self.onFocus();
+			// Fix https://github.com/orchidjs/tom-select/issues/806
+			// Only proceed if this instance's element is still the active element. If Edge autofill
+			// (or anything else) has moved focus to a different element in the interim, calling
+			// onFocus() here would steal focus back and restart the cascade loop.
+			if (document.activeElement === focusTarget || this.control.contains(document.activeElement)) {
+        		this.onFocus();
+      		}
 		}, 0);
 	}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1297,7 +1297,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// (or anything else) has moved focus to a different element in the interim, calling
 			// onFocus() here would steal focus back and restart the cascade loop.
 			const root = focusTarget.getRootNode() as Document | ShadowRoot;
-			if (!self.isFocused || (root.activeElement !== focusTarget) {
+			if (!self.isFocused || root.activeElement !== focusTarget) {
         		return;
       		}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1296,9 +1296,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// Only proceed if this instance's element is still the active element. If Edge autofill
 			// (or anything else) has moved focus to a different element in the interim, calling
 			// onFocus() here would steal focus back and restart the cascade loop.
-			const root = focusTarget.getRootNode();
-			const activeElement = root.activeElement;
-			if (activeElement !== focusTarget) {
+			const root = focusTarget.getRootNode() as Document | ShadowRoot;
+			if (root.activeElement !== focusTarget) {
         		return;
       		}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1296,9 +1296,13 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// Only proceed if this instance's element is still the active element. If Edge autofill
 			// (or anything else) has moved focus to a different element in the interim, calling
 			// onFocus() here would steal focus back and restart the cascade loop.
-			if (document.activeElement === focusTarget || this.control.contains(document.activeElement)) {
-        		this.onFocus();
+			const root = focusTarget.getRootNode();
+			const activeElement = root.activeElement;
+			if (activeElement !== focusTarget) {
+        		return;
       		}
+
+			this.onFocus();
 		}, 0);
 	}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1297,7 +1297,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// (or anything else) has moved focus to a different element in the interim, calling
 			// onFocus() here would steal focus back and restart the cascade loop.
 			const root = focusTarget.getRootNode() as Document | ShadowRoot;
-			if (root.activeElement !== focusTarget) {
+			if (!self.isFocused || (root.activeElement !== focusTarget) {
         		return;
       		}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1297,7 +1297,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// (or anything else) has moved focus to a different element in the interim, calling
 			// onFocus() here would steal focus back and restart the cascade loop.
 			const root = focusTarget.getRootNode() as Document | ShadowRoot;
-			if (!self.isFocused || root.activeElement !== focusTarget) {
+			if (root.activeElement !== focusTarget) {
         		return;
       		}
 

--- a/test/tests/interaction.js
+++ b/test/tests/interaction.js
@@ -265,6 +265,46 @@
 				});
 			});
 
+			it_n('should not call onFocus if focus moved to another element before timeout', function(done) {
+
+				var test = setup_test('AB_Single',{
+					items:['a']
+				});
+				var other = document.createElement('input');
+				document.body.appendChild(other);
+
+				var called = false;
+				test.instance.onFocus = function(){
+					called = true;
+				};
+				test.instance.focus();
+
+				// simulate something stealing focus (eg. autofill)
+				other.focus();
+
+				setTimeout(function() {
+					expect(document.activeElement).to.equal(other);
+					expect(called).to.equal(false);
+					done();
+				}, 20);
+			});
+
+			it_n('should call onFocus if focus remains on control', function(done) {
+
+				var test = setup_test('AB_Single',{
+					items:['a']
+				});
+				var called = false;
+				test.instance.onFocus = function(){
+					called = true;
+				};
+				test.instance.focus();
+
+				setTimeout(function(){
+					expect(called).to.equal(true);
+					done();
+				}, 20);
+			});
 
 			it_n('should remain open but clear active item on click', function(done) {
 				var test = setup_test('AB_Multi');

--- a/test/tests/interaction.js
+++ b/test/tests/interaction.js
@@ -265,30 +265,6 @@
 				});
 			});
 
-			it_n('should not call onFocus if focus moved to another element before timeout', function(done) {
-
-				var test = setup_test('AB_Single',{
-					items:['a']
-				});
-				var other = document.createElement('input');
-				document.body.appendChild(other);
-
-				var called = false;
-				test.instance.onFocus = function(){
-					called = true;
-				};
-				test.instance.focus();
-
-				// simulate something stealing focus (eg. autofill)
-				other.focus();
-
-				setTimeout(function() {
-					expect(document.activeElement).to.equal(other);
-					expect(called).to.equal(false);
-					done();
-				}, 20);
-			});
-
 			it_n('should call onFocus if focus remains on control', function(done) {
 
 				var test = setup_test('AB_Single',{


### PR DESCRIPTION
Use a single focusTarget (control_input or focus_node) and only call onFocus after the timeout if the instance still has focus. This prevents Edge autofill (or other handlers) from moving focus and having onFocus steal it back, fixing #806. Added unit tests to ensure onFocus is not called when focus moves to another element and is called when focus remains on the control.

Solution taken from here: https://github.com/netbox-community/netbox/pull/21645
fixes #806 

The found root cause sounds good but i can't reproduce the origin problem on my client (doesn't use Edge, doesn't use password fields managers in browser). I tried to build testcases to check if this fix is working.

**Origin root cause description:**
>  **Root cause:** TomSelect's open() method calls focus(), which synchronously moves browser focus to this instance's control input, then schedules setTimeout(onFocus, 0). When Edge autofill has moved focus to a *different* select before the timeout fires, the delayed onFocus() call re-steals browser focus back, causing the other instance to blur and close. Each instance's deferred callback then repeats this, creating an infinite ping-pong loop.
> 
> **Fix:** in the setTimeout callback, only proceed with onFocus() if this instance's element is still the active element. If focus has already moved elsewhere, skip the call.