### PR TITLE
Fix dropdown scrolling to top when the virtual scroll plugin fetch next page

### DIFF
--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -1,5 +1,5 @@
 /**
- * Plugin: "restore_on_backspace" (Tom Select)
+ * Plugin: "virtual_scroll" (Tom Select)
  * Copyright (c) contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
@@ -148,6 +148,18 @@ export default function(this:TomSelect) {
 		orig_loadCallback.call( self, options, optgroups);
 
 		loading_more = false;
+	});
+
+
+	// as the “loading_more” element will be removed from the dropdown,
+	// we activate the previous option if needed
+	// to avoid the dropdown being scrolled back to the first one
+	self.hook('before','refreshOptions',()=>{
+
+		if (self.activeOption && "option" !== self.activeOption.getAttribute("role")) {
+			self.setActiveOption(self.activeOption.previousElementSibling as HTMLElement);
+		}
+
 	});
 
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -73,6 +73,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	public isFocused				: boolean = false;
 	public isInputHidden			: boolean = false;
 	public isSetup					: boolean = false;
+	public isDropdownContentStale	: boolean = true;
 	public ignoreFocus				: boolean = false;
 	public ignoreHover				: boolean = false;
 	public hasOptions				: boolean = false;
@@ -546,8 +547,6 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		self.setupOptions(settings.options,settings.optgroups);
 
 		self.setValue(settings.items||[],true); // silent prevents recursion
-
-		self.lastQuery = null; // so updated options will be displayed in dropdown
 	}
 
 	/**
@@ -893,7 +892,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		} else {
 			value = option.dataset.value;
 			if (typeof value !== 'undefined') {
-				self.lastQuery = null;
+				self.isDropdownContentStale = self.settings.hideSelected;
 				self.addItem(value);
 				if (self.settings.closeAfterSelect) {
 					self.close();
@@ -983,7 +982,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	loadCallback( options:TomOption[], optgroups:TomOption[] ):void{
 		const self = this;
 		self.loading = Math.max(self.loading - 1, 0);
-		self.lastQuery = null;
+		self.isDropdownContentStale = true;
 
 		self.clearActiveOption(); // when new results load, focus should be on first option
 		self.setupOptions(options,optgroups);
@@ -1360,7 +1359,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		}
 
 		// perform search
-		if (query !== self.lastQuery) {
+		if (self.isDropdownContentStale || query !== self.lastQuery) {
 			self.lastQuery			= query;
 			// temp fix for https://github.com/orchidjs/tom-select/issues/987
 			// UI crashed when more than 30 same chars in a row, prevent search and return empt result
@@ -1547,6 +1546,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		dropdown_content.innerHTML = '';
 		append( dropdown_content, html );
+		self.isDropdownContentStale = false;
 
 		// highlight matching terms inline
 		if (self.settings.highlight) {
@@ -1666,10 +1666,10 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			return false;
 		}
 
-		data.$order			= data.$order || ++self.order;
-		data.$id			= self.inputId + '-opt-' + data.$order;
-		self.options[key]	= data;
-		self.lastQuery		= null;
+		data.$order					= data.$order || ++self.order;
+		data.$id					= self.inputId + '-opt-' + data.$order;
+		self.options[key]			= data;
+		self.isDropdownContentStale	= true;
 
 		if( user_created ){
 			self.userOptions[key] = user_created;
@@ -1810,8 +1810,8 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			replaceNode( item, item_new);
 		}
 
-		// invalidate last query because we might have updated the sortField
-		self.lastQuery = null;
+		// we might have updated the sortField
+		self.isDropdownContentStale = true;
 	}
 
 	/**
@@ -1826,7 +1826,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 		delete self.userOptions[value];
 		delete self.options[value];
-		self.lastQuery = null;
+		self.isDropdownContentStale = true;
 		self.trigger('option_remove', value);
 		self.removeItem(value, silent);
 	}
@@ -1850,7 +1850,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		});
 
 		this.options = this.sifter.items = selected;
-		this.lastQuery = null;
+		this.isDropdownContentStale = true;
 		this.trigger('option_clear');
 	}
 
@@ -2064,7 +2064,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 		}
 
 		self.items.splice(i, 1);
-		self.lastQuery = null;
+		self.isDropdownContentStale = true;
 		if (!self.settings.persist && self.userOptions.hasOwnProperty(value)) {
 			self.removeOption(value, silent);
 		}
@@ -2156,7 +2156,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 	 */
 	refreshItems() {
 		var self = this;
-		self.lastQuery = null;
+		self.isDropdownContentStale = true;
 
 		if (self.isSetup) {
 			self.addItems(self.items);

--- a/test/tests/plugins/virtual_scroll.js
+++ b/test/tests/plugins/virtual_scroll.js
@@ -27,9 +27,9 @@ describe('plugin: virtual_scroll', function() {
 
 	it_n('load more data while scrolling',async ()=>{
 
-		var load_calls = 0;
+		let load_calls = 0;
 
-		var test = setup_test('<input>',{
+		const test = setup_test('<input>',{
 			plugins:['virtual_scroll'],
 			labelField: 'value',
 			valueField: 'value',
@@ -53,18 +53,21 @@ describe('plugin: virtual_scroll', function() {
 		await asyncType('a');
 		await waitFor(100); // wait for data to load
 		assert.equal( Object.keys(test.instance.options).length,20,'should load first set of data');
-		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 1, 'should have loading-more-reuslts template');
+		const loadingMoreIndicator = test.instance.dropdown_content.querySelector('.loading-more-results');
+		assert.isNotNull( loadingMoreIndicator, 'should have loading_more template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.no-more-results').length, 0 ,'should not have no-more-results template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.option').length, 21 ,'Should display 20 options plus .loading-more-results');
 
 		assert.equal( load_calls, 1);
 
+		const lastOption = loadingMoreIndicator.previousElementSibling;
 
 		// load second set of data for "a"
-		test.instance.scroll(1000,'auto'); // scroll to bottom
+		test.instance.setActiveOption(loadingMoreIndicator); // scroll to bottom
 		await waitFor(500); // wait for scroll + more data to load
 		assert.equal( Object.keys(test.instance.options).length, 40,'should load second set of data');
-		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 0, 'should not have loading-more-reuslts template');
+		assert.equal( lastOption, test.instance.activeOption, 'previous dataset’s last option should be active')
+		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 0, 'should not have loading_more template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.no-more-results').length, 1 ,'should have no-more-results template');
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.option').length, 31 ,'Should display 30 options plus .no-more-results');
 		assert.equal( load_calls, 2);
@@ -79,7 +82,7 @@ describe('plugin: virtual_scroll', function() {
 
 		// load first set of data for "b"
 		await asyncType('\bb');
-		await waitFor(100); // wait for data to load
+		await waitFor(500); // wait for data to load
 		assert.equal( Object.keys(test.instance.options).length,20,'should load new set of data for "b"');
 		assert.equal( load_calls, 3);
 	});

--- a/test/tests/plugins/virtual_scroll.js
+++ b/test/tests/plugins/virtual_scroll.js
@@ -48,10 +48,16 @@ describe('plugin: virtual_scroll', function() {
 			}
 		});
 
+		let executor = (resolve) => test.instance.on('load', () => {
+			test.instance.off('load');
+			resolve();
+		});
+
 		// load first set of data for "a"
+		let dataLoaded = new Promise(executor);
 		await asyncClick(test.instance.control);
 		await asyncType('a');
-		await waitFor(100); // wait for data to load
+		await dataLoaded;
 		assert.equal( Object.keys(test.instance.options).length,20,'should load first set of data');
 		const loadingMoreIndicator = test.instance.dropdown_content.querySelector('.loading-more-results');
 		assert.isNotNull( loadingMoreIndicator, 'should have loading_more template');
@@ -63,8 +69,9 @@ describe('plugin: virtual_scroll', function() {
 		const lastOption = loadingMoreIndicator.previousElementSibling;
 
 		// load second set of data for "a"
+		dataLoaded = new Promise(executor);
 		test.instance.setActiveOption(loadingMoreIndicator); // scroll to bottom
-		await waitFor(500); // wait for scroll + more data to load
+		await dataLoaded;
 		assert.equal( Object.keys(test.instance.options).length, 40,'should load second set of data');
 		assert.equal( lastOption, test.instance.activeOption, 'previous dataset’s last option should be active')
 		assert.equal( test.instance.dropdown_content.querySelectorAll('.loading-more-results').length, 0, 'should not have loading_more template');
@@ -81,8 +88,9 @@ describe('plugin: virtual_scroll', function() {
 
 
 		// load first set of data for "b"
+		dataLoaded = new Promise(executor);
 		await asyncType('\bb');
-		await waitFor(500); // wait for data to load
+		await dataLoaded;
 		assert.equal( Object.keys(test.instance.options).length,20,'should load new set of data for "b"');
 		assert.equal( load_calls, 3);
 	});


### PR DESCRIPTION
Reopens #821

Fixes #556 (closed for inactivity but still present).

I stumbled upon two distinct issues when investigating this one:

- the `lastQuery` property was used for checking the UI staleness, as such it was often reset independently of the search query. When the virtual scroll plugin triggers `refreshOptions` the UI is stale so the first option is activated and scrolled to, while it shouldn’t happen since the query didn’t change. This is fixed by splitting the staleness check in a `isDropdownContentStale` property, which is updated independently of `lastQuery`.
- the “loading_more” element is made so that you can select it when navigating using the keyboard. Problem is, it will be removed by `refreshOptions` which then won’t find it in the dropdown and activate — and scroll to — the first option.