### PR TITLE
Security: DOM XSS risk from unescaped plugin template fields in clear_button

### DIFF
--- a/src/plugins/clear_button/plugin.ts
+++ b/src/plugins/clear_button/plugin.ts
@@ -26,8 +26,18 @@ export default function(this:TomSelect, userOptions:CBOptions) {
 		role: 'button',
 		tabindex: 0,
 		html: (data:CBOptions) => {
+			const div = document.createElement('div');
+			const className = (data.className || '').split(/\s+/).filter(token => /^[A-Za-z0-9_-]+$/.test(token)).join(' ');
+			const role = data.role === 'button' ? data.role : 'button';
+			const tabindex = Number.parseInt(String(data.tabindex),10);
 
-		return `<div class="${data.className}" title="${data.title}" role="${data.role}" tabindex="${data.tabindex}">&times;</div>`;
+			div.className = className || 'clear-button';
+			div.title = data.title || '';
+			div.setAttribute('role', role);
+			div.tabIndex = Number.isFinite(tabindex) ? tabindex : 0;
+			div.textContent = '\u00d7';
+
+			return div;
 		}
 	}, userOptions);
 

--- a/src/plugins/dropdown_header/plugin.ts
+++ b/src/plugins/dropdown_header/plugin.ts
@@ -29,14 +29,26 @@ export default function(this:TomSelect, userOptions:DHOptions) {
 		closeClass    : 'dropdown-header-close',
 
 		html: (data:DHOptions) => {
-			return (
-				'<div class="' + data.headerClass + '">' +
-					'<div class="' + data.titleRowClass + '">' +
-						'<span class="' + data.labelClass + '">' + data.title + '</span>' +
-						'<a class="' + data.closeClass + '">&times;</a>' +
-					'</div>' +
-				'</div>'
-			);
+			const header = document.createElement('div');
+			const titleRow = document.createElement('div');
+			const label = document.createElement('span');
+			const close = document.createElement('a');
+			const headerClass = (data.headerClass || '').split(/\s+/).filter(token => /^[A-Za-z0-9_-]+$/.test(token)).join(' ');
+			const titleRowClass = (data.titleRowClass || '').split(/\s+/).filter(token => /^[A-Za-z0-9_-]+$/.test(token)).join(' ');
+			const labelClass = (data.labelClass || '').split(/\s+/).filter(token => /^[A-Za-z0-9_-]+$/.test(token)).join(' ');
+			const closeClass = (data.closeClass || '').split(/\s+/).filter(token => /^[A-Za-z0-9_-]+$/.test(token)).join(' ');
+
+			header.className = headerClass || 'dropdown-header';
+			titleRow.className = titleRowClass || 'dropdown-header-title';
+			label.className = labelClass || 'dropdown-header-label';
+			close.className = closeClass || 'dropdown-header-close';
+			label.textContent = data.title || '';
+			close.textContent = '\u00d7';
+
+			titleRow.append(label, close);
+			header.appendChild(titleRow);
+
+			return header;
 		}
 	}, userOptions);
 


### PR DESCRIPTION
## Problem

The default `html` renderer builds an HTML string using `className`, `title`, `role`, and `tabindex` via string interpolation, then parses it with `getDom()`. If any of these option values are attacker-controlled (for example, passed from untrusted JSON config), attribute injection and script execution are possible.

**Severity**: `high`
**File**: `src/plugins/clear_button/plugin.ts`

## Solution

Avoid string-built HTML for option-driven values. Create elements with `document.createElement`, assign `textContent`, and set attributes via `setAttribute` after strict allowlisting/validation (`role` enum, numeric `tabindex`, safe class token pattern). If templating is required, escape all interpolated values.

## Changes

- `src/plugins/clear_button/plugin.ts` (modified)
- `src/plugins/dropdown_header/plugin.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
