### PR TITLE
Security: DOM XSS risk from unescaped dropdown_header template content

### DIFF
--- a/src/plugins/clear_button/plugin.ts
+++ b/src/plugins/clear_button/plugin.ts
@@ -20,6 +20,19 @@ import { CBOptions } from './types.ts';
 export default function(this:TomSelect, userOptions:CBOptions) {
 	const self = this;
 
+	const escape_html = (value:string) => {
+		return String(value)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	};
+
+	const sanitize_classes = (value:string) => {
+		return String(value).replace(/[^A-Za-z0-9_\-\s]/g, '').trim();
+	};
+
 	const options = Object.assign({
 		className: 'clear-button',
 		title: 'Clear All',
@@ -27,7 +40,7 @@ export default function(this:TomSelect, userOptions:CBOptions) {
 		tabindex: 0,
 		html: (data:CBOptions) => {
 
-		return `<div class="${data.className}" title="${data.title}" role="${data.role}" tabindex="${data.tabindex}">&times;</div>`;
+		return `<div class="${sanitize_classes(data.className)}" title="${escape_html(data.title)}" role="${escape_html(data.role)}" tabindex="${escape_html(data.tabindex)}">&times;</div>`;
 		}
 	}, userOptions);
 

--- a/src/plugins/dropdown_header/plugin.ts
+++ b/src/plugins/dropdown_header/plugin.ts
@@ -21,6 +21,19 @@ import { DHOptions } from './types.ts';
 export default function(this:TomSelect, userOptions:DHOptions) {
 	const self = this;
 
+	const escape_html = (value:string) => {
+		return String(value)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	};
+
+	const sanitize_classes = (value:string) => {
+		return String(value).replace(/[^A-Za-z0-9_\-\s]/g, '').trim();
+	};
+
 	const options = Object.assign({
 		title         : 'Untitled',
 		headerClass   : 'dropdown-header',
@@ -30,10 +43,10 @@ export default function(this:TomSelect, userOptions:DHOptions) {
 
 		html: (data:DHOptions) => {
 			return (
-				'<div class="' + data.headerClass + '">' +
-					'<div class="' + data.titleRowClass + '">' +
-						'<span class="' + data.labelClass + '">' + data.title + '</span>' +
-						'<a class="' + data.closeClass + '">&times;</a>' +
+				'<div class="' + sanitize_classes(data.headerClass) + '">' +
+					'<div class="' + sanitize_classes(data.titleRowClass) + '">' +
+						'<span class="' + sanitize_classes(data.labelClass) + '">' + escape_html(data.title) + '</span>' +
+						'<a class="' + sanitize_classes(data.closeClass) + '">&times;</a>' +
 					'</div>' +
 				'</div>'
 			);
@@ -43,7 +56,8 @@ export default function(this:TomSelect, userOptions:DHOptions) {
 	self.on('initialize',()=>{
 		var header = getDom(options.html(options));
 
-		var close_link = header.querySelector('.'+options.closeClass);
+		var close_class = sanitize_classes(options.closeClass).split(/\s+/)[0];
+		var close_link = close_class ? header.querySelector('.'+close_class) : null;
 		if( close_link ){
 			close_link.addEventListener('click',(evt)=>{
 				preventDefault(evt,true);


### PR DESCRIPTION
## Problem

The plugin’s default template concatenates `title` and class-name options directly into HTML and inserts it into the DOM with `getDom()`. Untrusted values in `title` or class fields can inject markup/event handlers.

**Severity**: `high`
**File**: `src/plugins/dropdown_header/plugin.ts`

## Solution

Build header nodes using DOM APIs instead of HTML string concatenation. Set visible text through `textContent` (not `innerHTML`) and sanitize/allowlist class names. If retaining string templates, escape all interpolated values before insertion.

## Changes

- `src/plugins/dropdown_header/plugin.ts` (modified)
- `src/plugins/clear_button/plugin.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
