### PR TITLE
bug/minor: fix multi item padding for bs themes

### DIFF
--- a/src/scss/tom-select.bootstrap4.scss
+++ b/src/scss/tom-select.bootstrap4.scss
@@ -33,7 +33,7 @@ $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !defa
 $select-opacity-disabled: 0.5 !default;
 $select-border: 1px solid $input-border-color !default;
 $select-border-radius: $input-border-radius !default;
-$select-width-item-border: 0 !default;
+$select-width-item-border: 0px !default;
 $select-padding-x: $input-btn-padding-x !default;
 $select-padding-y: $input-btn-padding-y !default;
 $select-padding-dropdown-item-x: $input-btn-padding-x !default;

--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -31,7 +31,7 @@ $select-color-dropdown-item-create-active-text: $dropdown-link-hover-color !defa
 $select-opacity-disabled: 1 !default;
 $select-border: 1px solid $input-border-color !default;
 $select-border-radius: $input-border-radius !default;
-$select-width-item-border: 0 !default;
+$select-width-item-border: 0px !default;
 $select-padding-x: $input-padding-x !default;
 $select-padding-y: $input-padding-y !default;
 $select-padding-dropdown-item-x: $input-btn-padding-x !default;


### PR DESCRIPTION
<!--
Thanks for taking the time to improve Tom Select. We really appreciate it.

Before opening the PR, please:

* Make sure tests pass by running `npm test`
* Do not make changes to the /dist folder

In the best case scenario, you are also adding tests to back up your changes,
but don't sweat it if you don't. We can discuss them at a later date.

Thanks again, we really appreciate this!
-->

This var ends up in a [`calc()` call](https://github.com/orchidjs/tom-select/blob/02342bbffe491b050f996b7dc3f31a61557f8f41/src/scss/_items.scss#L17), where unitless zeroes are invalid. As a result, that rule doesn't actually apply and multi items have _slightly_ more bottom padding than they should (at least when using bs4).

It looks like this was removed at the behest of `stylelint`, which is understandable given how far removed it is from the calc call, but still wrong.