### PR TITLE
fix dom order

### DIFF
--- a/doc_src/pages/docs/index.md
+++ b/doc_src/pages/docs/index.md
@@ -290,6 +290,13 @@ tom.inputState();
 		<td><code>boolean</td>
 		<td><code>false</code></td>
 	</tr>
+	<tr>
+		<td><code>keepOrder</code></td>
+		<td>When set to <code>true</code>, the HTML/DOM order of options will kept. (This feature isn't nessessary on single select instances.)
+		<b>Note:</b> When this option is enabled, the display order of selection get lost and users will see the order of DOM structure.</td>
+		<td><code>boolean</td>
+		<td><code>false</code></td>
+	</tr>
 </table>
 
 ## Data / Searching

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -25,6 +25,7 @@ export default {
 	allowEmptyOption: false,
 	//closeAfterSelect: false,
 	refreshThrottle: 300,
+	keepOrder: false,
 
 
 	loadThrottle: 300,

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2257,7 +2257,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 				// don't move empty option from top of list
 				// fixes bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1725293
-				if( option_el != empty_option && (!self.settings.keepOrder && self.settings.mode != 'single') ){
+				if( option_el != empty_option && ( !self.settings.keepOrder && self.settings.mode != 'single' || create ) ){
 					self.input.append(option_el);
 				}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2257,7 +2257,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 				// don't move empty option from top of list
 				// fixes bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1725293
-				if( option_el != empty_option ){
+				if( option_el != empty_option && (!self.settings.keepOrder && self.settings.mode != 'single') ){ {
 					self.input.append(option_el);
 				}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2257,7 +2257,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 				// don't move empty option from top of list
 				// fixes bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1725293
-				if( option_el != empty_option && (!self.settings.keepOrder && self.settings.mode != 'single') ){ {
+				if( option_el != empty_option && (!self.settings.keepOrder && self.settings.mode != 'single') ){
 					self.input.append(option_el);
 				}
 

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2249,7 +2249,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			const selected:HTMLOptionElement[]		= [];
 			const has_selected:number				= self.input.querySelectorAll('option:checked').length;
 
-			function AddSelected(option_el:HTMLOptionElement|null, value:string, label:string):HTMLOptionElement{
+			function AddSelected(option_el:HTMLOptionElement|null, create:boolean, value:string, label:string):HTMLOptionElement{
 
 				if( !option_el ){
 					option_el = getDom('<option value="' + escape_html(value) + '">' + escape_html(label) + '</option>') as HTMLOptionElement;
@@ -2281,7 +2281,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 			// nothing selected?
 			if( self.items.length == 0 && self.settings.mode == 'single' ){
 
-				AddSelected(empty_option, "", "");
+				AddSelected(empty_option, false, "", "");
 
 			// order selected <option> tags for values in self.items
 			}else{
@@ -2292,9 +2292,9 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 					if( selected.includes(option.$option) ){
 						const reuse_opt = self.input.querySelector(`option[value="${addSlashes(value)}"]:not(:checked)`) as HTMLOptionElement;
-						AddSelected(reuse_opt, value, label);
+						AddSelected(reuse_opt, false, value, label);
 					}else{
-						option.$option	= AddSelected(option.$option, value, label);
+						option.$option	= AddSelected(option.$option, true, value, label);
 					}
 				});
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -33,6 +33,7 @@ export type TomSettings = {
 	closeAfterSelect		: boolean,
 	clearAfterSelect		: boolean,
 	refreshThrottle			: number,
+	keepOrder				: boolean,
 
 	loadThrottle			: number,
 	loadingClass			: string,


### PR DESCRIPTION
This PR add a new option to maintain the HTML/DOM order.

At the moment, tom-select adds all selected items at the end in the dom. This is not a bug, it's a feature. With this feature, the users sees on the select input the right order in which the options are selected. The problem is, when using optgroups, the dom is broken because the options inside an optgroup leaving the group and will be placed at the end of the list.

With this PR i implement these changes:
- When select is in single mode (only one option is selectable), the order will be kept. Users can only see one option and no order is required
- When select is not in single mode and the new parameter `keepOrder` is false, the current behavior still exists. 
- When select is not in single mode and the new parameter `keepOrder` is true, the DOM will keep the correct order but the user see the selection options in order given by DOM.


This PR:
fixes #1040 
fixes #938 