### PR TITLE
move empty option to top of list

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2255,7 +2255,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 					option_el = getDom('<option value="' + escape_html(value) + '">' + escape_html(label) + '</option>') as HTMLOptionElement;
 				}
 
-				if( option_el == empty_option ){
+				if( !value ){
 					self.input.prepend(option_el);
 				} else {
 					self.input.append(option_el);

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2255,9 +2255,9 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 					option_el = getDom('<option value="' + escape_html(value) + '">' + escape_html(label) + '</option>') as HTMLOptionElement;
 				}
 
-				// don't move empty option from top of list
-				// fixes bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1725293
-				if( option_el != empty_option ){
+				if( option_el == empty_option ){
+					self.input.prepend(option_el);
+				} else {
 					self.input.append(option_el);
 				}
 


### PR DESCRIPTION
partially reverts e757c8c0d4c7a950f593551c9275550c1d543aaf since the firefox bug was already fixed

fixes #858 
