### PR TITLE
Allow editing the HTML for the `remove_button` plugin

### DIFF
--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -24,18 +24,12 @@ export default function(this:TomSelect, userOptions:RBOptions) {
 	const options = Object.assign({
 			label     : '&times;',
 			title     : 'Remove',
-			className : 'remove',
-			append    : true
+			className : 'remove'
 		}, userOptions);
 
 
 	//options.className = 'remove-single';
 	var self			= this;
-
-	// override the render method to add remove button to each item
-	if( !options.append ){
-		return;
-	}
 
 	var html = '<a href="javascript:void(0)" class="' + options.className + '" tabindex="-1" title="' + escape_html(options.title) + '">' + options.label + '</a>';
 

--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -20,18 +20,19 @@ import { TomOption, TomItem } from '../../types/index.ts';
 import { RBOptions } from './types.ts';
 
 export default function(this:TomSelect, userOptions:RBOptions) {
+	const self = this;
 
 	const options = Object.assign({
 			label     : '&times;',
 			title     : 'Remove',
-			className : 'remove'
+			className : 'remove',
+			tabindex  : -1,
+			role      : 'button',
+			html      : (data:RBOptions) => {
+				return `<div class="${data.className}" title="${data.title}" role="${data.role}" tabindex="${data.tabindex}">${data.label}</div>`;
+			}
 		}, userOptions);
 
-
-	//options.className = 'remove-single';
-	var self			= this;
-
-	var html = '<a href="javascript:void(0)" class="' + options.className + '" tabindex="-1" title="' + escape_html(options.title) + '">' + options.label + '</a>';
 
 	self.hook('after','setupTemplates',() => {
 
@@ -41,7 +42,7 @@ export default function(this:TomSelect, userOptions:RBOptions) {
 
 			var item = getDom(orig_render_item.call(self, data, escape)) as TomItem;
 
-			var close_button = getDom(html);
+			var close_button = getDom(options.html(options));
 			item.appendChild(close_button);
 
 			addEvent(close_button,'mousedown',(evt) => {

--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -29,7 +29,15 @@ export default function(this:TomSelect, userOptions:RBOptions) {
 			tabindex  : -1,
 			role      : 'button',
 			html      : (data:RBOptions) => {
-				return `<div class="${data.className}" title="${data.title}" role="${data.role}" tabindex="${data.tabindex}">${data.label}</div>`;
+				const el = document.createElement('div');
+
+				el.className = data.className || '';
+				el.title = data.title || '';
+				el.setAttribute('role', data.role || 'button');
+				el.tabIndex = data.tabindex ?? -1;
+				el.textContent = data.label || '';
+
+				return el;
 			}
 		}, userOptions);
 

--- a/src/plugins/remove_button/types.ts
+++ b/src/plugins/remove_button/types.ts
@@ -2,6 +2,5 @@
 export type RBOptions = {
 	label     ?: string,
 	title     ?: string,
-	className ?: string,
-	append    ?: boolean
+	className ?: string
 };

--- a/src/plugins/remove_button/types.ts
+++ b/src/plugins/remove_button/types.ts
@@ -2,5 +2,8 @@
 export type RBOptions = {
 	label     ?: string,
 	title     ?: string,
-	className ?: string
+	className ?: string,
+	tabindex  ?: number,
+	role      ?: string,
+	html      ?: (data: RBOptions) => string,
 };


### PR DESCRIPTION
The `remove_button` plugin currently uses a `javascript:void(0)` link that doesn't work well with a strict CSP, requiring unsafe CSP directives for them to work.

Inspired by how the `clear_button` plugin works, this Pull Request replaces the `<a>` element with a `<div role="button">` element behind an `html` option that can be overridden. This will ensure that any application that can switch it for a proper button element can do it on the application side.

As part of this work, an unused `append` option was removed from the plugin. It was previously used by Selectize, and became a dead code path 6 years ago on 1cb332caea2073d9280921ff1a9ab2a165484986.