### PR TITLE
Use multiplication sign directly

### DIFF
--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -23,7 +23,7 @@ export default function(this:TomSelect, userOptions:RBOptions) {
 	const self = this;
 
 	const options = Object.assign({
-			label     : '&times;',
+			label     : '×',
 			title     : 'Remove',
 			className : 'remove',
 			tabindex  : -1,


### PR DESCRIPTION
PR #1050 changed the `remove_button` plugin from interpolating HTML directly to creating the element using `document.createElement`. As defining `textContent` does not decode HTML entities, a literal "&times;" string is now shown instead of the multiplication sign.

This commit replaces the HTML entity with the literal unicode character.

Fixes #1051