### PR TITLE
feat: allow null maxOptions in virtual_scroll plugin

### DIFF
--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -69,7 +69,10 @@ export default function(this:TomSelect) {
 	// can we load more results for given query?
 	const canLoadMore = (query:string):boolean => {
 
-		if( typeof self.settings.maxOptions === 'number' && dropdown_content.children.length >= self.settings.maxOptions ){
+		if( self.settings.maxOptions !== null
+			&& typeof self.settings.maxOptions === 'number'
+			&& dropdown_content.children.length >= self.settings.maxOptions
+		){
 			return false;
 		}
 


### PR DESCRIPTION
Is there a reason that the plugin restricts the maximum number of options? The library supports "large datasets" (there's an example for it), so ideally the plugin just keeps loading until there's no more data.

The reason for this change is that when `max_options` is met, but there is still more data (`next_url` is set), it shows `No more results` at the end of the dropdown options which is not true...