### PR TITLE
fix: allow empty option selection in multi-select

### DIFF
--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -2265,7 +2265,7 @@ export default class TomSelect extends MicroPlugin(MicroEvent){
 
 				// marking empty option as selected can break validation
 				// fixes https://github.com/orchidjs/tom-select/issues/303
-				if( option_el != empty_option || has_selected > 0 ){
+				if( option_el != empty_option || has_selected > 0 || self.settings.mode == 'multi' ){
 					option_el.selected = true;
 				}
 

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -102,13 +102,15 @@ describe('Configuration settings', function() {
 
 	});
 
-	it_n('allowEmptyOption', async () => {
+	it_n('allowEmptyOption should select empty option first in multi-select', async () => {
 
-		let test = setup_test(`<select multiple>
-				<option value="">None</option>
-				<option value="4">Thomas Edison</option>
-				<option value="1">Nikola</option>
-			</select>`, {allowEmptyOption:true});
+		let test = setup_test(`<form>
+				<select multiple name="project" class="setup-here">
+					<option value="">Not assigned</option>
+					<option value="a">A</option>
+					<option value="b">B</option>
+				</select>
+			</form>`, {allowEmptyOption:true});
 
 		assert.equal( Object.keys(test.instance.options).length, 3);
 		assert.equal( test.instance.items.length, 0);
@@ -118,6 +120,42 @@ describe('Configuration settings', function() {
 		var opt = test.instance.getOption('');
 		await asyncClick(opt);
 		assert.equal( test.instance.items.length, 1);
+		assert.deepEqual( test.instance.getValue(), ['']);
+		assert.isTrue( test.select.querySelector('option[value=""]').selected );
+		assert.deepEqual( Array.from(test.select.selectedOptions).map(option => option.value), ['']);
+		assert.deepEqual( new FormData(test.html).getAll('project'), ['']);
+	});
+
+	it_n('allowEmptyOption should select empty option after non-empty option in multi-select', async () => {
+
+		let test = setup_test(`<form>
+				<select multiple name="project" class="setup-here">
+					<option value="">Not assigned</option>
+					<option value="a">A</option>
+					<option value="b">B</option>
+				</select>
+			</form>`, {allowEmptyOption:true});
+
+		await asyncClick(test.instance.control);
+		await asyncClick(test.instance.getOption('a'));
+		await asyncClick(test.instance.getOption(''));
+
+		assert.deepEqual( test.instance.getValue(), ['a','']);
+		assert.sameMembers( Array.from(test.select.selectedOptions).map(option => option.value), ['a','']);
+		assert.sameMembers( new FormData(test.html).getAll('project'), ['a','']);
+	});
+
+	it_n('allowEmptyOption false should not add empty option in multi-select', () => {
+
+		let test = setup_test(`<select multiple>
+				<option value="">Not assigned</option>
+				<option value="a">A</option>
+				<option value="b">B</option>
+			</select>`);
+
+		assert.isNull( test.instance.getOption('') );
+		test.instance.addItem('');
+		assert.deepEqual( test.instance.getValue(), []);
 	});
 
 	it_n('allowEmptyOption + hideSelected should hide selected empty option', async () => {


### PR DESCRIPTION
## Summary
  Fixes multi-select behavior when `allowEmptyOption` is enabled so an empty option can be selected and submitted like a normal option.

  Fixes #1055

  ## Root cause
  Tom Select intentionally avoided marking the empty option as selected to preserve validation behavior for single-select inputs. That guard also applied to multi-select inputs, so selecting an allowed empty
  option updated Tom Select state but did not mark the underlying `<option value="">` as selected.

  ## Changes
  - Allow the empty option to be marked selected when the control is in `multi` mode.
  - Preserve the existing single-select validation guard.
  - Add regression coverage for empty option selection in multi-select controls.

  ## Tests
  - Added coverage for selecting an empty option first in multi-select mode.
  - Added coverage for selecting an empty option after another option.
  - Added coverage that empty options remain unavailable when `allowEmptyOption` is false.