### PR TITLE
fix: bootstrap5 theme: update chevron in validation-state dropdown to support dark theme

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -65,7 +65,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 		}
 
 		&.single {
-			background-image: escape-svg($form-select-indicator), escape-svg($icon);
+			background-image: var(--bs-form-select-bg-img, escape-svg($form-select-indicator)), escape-svg($icon);
 			background-position: $form-select-bg-position, $form-select-feedback-icon-position;
 			background-size: $form-select-bg-size, $form-select-feedback-icon-size;
 			background-repeat: no-repeat;


### PR DESCRIPTION
Fixes #1061

## The problem

The chevron of a dropdown does not reflect the `data-bs-theme` used by the Bootstrap, when being validated. This covers `.is-valid`, `.is-invalid` and container with `.was-validated` class. It currently only has light theme version - dark gray which can be hard to notice with dark theme.

The problem targets Bootstrap versions `5.3.x`.

## What changed

Small `tom-select.bootstrap5.scss` one line change: 

```scss
background-image: escape-svg($form-select-indicator), escape-svg($icon);
```
changed to
```scss
background-image: var(--bs-form-select-bg-img, escape-svg($form-select-indicator)), escape-svg($icon);
```

in the `ts-form-validation-state-selector` mixin.

It gives preference to the dynamic Bootstrap variable for the chevron image that depends on the `data-bs-theme` directly. The fix also ensures there are no regressions, so there's the fallback for the older versions that do not offer the dark theme and `--bs-form-select-bg-img` Bootstrap variable.

## Before/After

This was run locally before and after the change, with the CSS link pointing to `dist/css/tom-select.bootstrap5.css` (after running `npm run build`) at the project root.

<h3 align="center">Before</h3>
<p align="center">
<img width="450" alt="127 0 0 1_5502_localcheck html" src="https://github.com/user-attachments/assets/04612044-a26c-49fa-8f72-2ee5a4bf9740" />
</p>

<h3 align="center">After</h3>
<p align="center">
<img width="450" alt="127 0 0 1_5502_localcheck html (1)" src="https://github.com/user-attachments/assets/19d695d9-ed6f-42aa-b578-0d8b7f249862" />
</p>

From the dev tools:
<img width="300" alt="Screenshot 2026-07-15 at 02 31 05" src="https://github.com/user-attachments/assets/5a520dd0-ee30-4e71-ad09-d94b322fabef" />

## Tests

Steps passed locally (node 22):

- [x] `npm test` - all tests passed
- [x] `npm run build` - successful build
- [x] `npm run stylelint` - successful, no output