### PR TITLE
fix: recover when stale preload response resolves after search starts

### DIFF
--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -161,14 +161,14 @@ export default function(this:TomSelect) {
 		orig_loadCallback.call( self, options, optgroups);
 
 		// After the initial preload (empty query), snapshot default_values and option objects
-		// so they can be restored when the user clears their search.
-		if( !loading_more && !default_values_loaded ){
+		// so they can be restored when the user clears their search. Only latch once a response for the
+		// empty query has actually been applied - a preload response that arrives after the user has
+		// already typed a search must not mark the (empty) defaults as loaded.
+		if( !loading_more && !default_values_loaded && self.lastValue === '' ){
 			default_values_loaded = true;
-			if( self.lastValue === '' ){
-				default_values = Object.keys(self.options);
-				default_pagination = pagination[''];
-				default_options = Object.values(self.options);
-			}
+			default_values = Object.keys(self.options);
+			default_pagination = pagination[''];
+			default_options = Object.values(self.options);
 		}
 
 		loading_more = false;
@@ -218,6 +218,12 @@ export default function(this:TomSelect) {
 	// Restore preloaded options and pagination when clearing search
 	const restoreDefaults = ():void => {
 		if( !default_values_loaded ) {
+			// The initial preload never completed (e.g. the user typed a search before it returned), so
+			// there is nothing to restore - re-arm the preload so the first page is fetched again.
+			self.wrapper.classList.remove('preloaded');
+			if( self.isFocused ){
+				self.preload();
+			}
 			return;
 		}
 		// Re-add preloaded option objects (clearOptions can only remove, not restore)

--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -15,13 +15,14 @@
 
 import type TomSelect from '../../tom-select.ts';
 import { TomOption } from '../../types/index.ts';
-import { addClasses } from '../../vanilla.ts';
+import { addClasses, removeClasses } from '../../vanilla.ts';
 
 export default function(this:TomSelect) {
 	const self							= this;
 	const orig_canLoad					= self.canLoad;
 	const orig_clearActiveOption		= self.clearActiveOption;
 	const orig_loadCallback				= self.loadCallback;
+	const orig_load						= self.load;
 
 	var pagination:{[key:string]:any}	= {};
 	var dropdown_content:HTMLElement;
@@ -32,6 +33,7 @@ export default function(this:TomSelect) {
 	var default_pagination:any;
 	var default_options: TomOption[]	= [];
 	var html_values: string[]			= [];
+	var preload_requested				= false;
 
 	if( !self.settings.shouldLoadMore ){
 
@@ -140,14 +142,37 @@ export default function(this:TomSelect) {
 	});
 
 
-	// wrap the load
-	self.hook('instead','loadCallback',( options:TomOption[], optgroups:TomOption[])=>{
+	// handle a load() response, knowing which query the request was originally issued for
+	const loadCallbackForQuery = ( query:string, was_loading_more:boolean, options:TomOption[], optgroups:TomOption[] ):void => {
+
+		loading_more = was_loading_more;
+
+		// The response belongs to a query the user has since changed, so applying it would
+		// overwrite the options displayed for the active query. Discard it, performing only the
+		// loading bookkeeping loadCallback() would otherwise do. Reset the stored pagination for
+		// the abandoned query - the load function may have already advanced it past pages that
+		// were never applied - so a later request for the same query starts from the first page.
+		if( query !== self.lastValue ){
+			self.loading = Math.max(self.loading - 1, 0);
+			if( !self.loading ){
+				removeClasses(self.wrapper,self.settings.loadingClass);
+			}
+			pagination[query] = self.settings.firstUrl.call(self,query);
+
+			// if the discarded response was the preload, allow preload() to run again
+			if( query === '' && !default_values_loaded ){
+				self.wrapper.classList.remove('preloaded');
+			}
+
+			loading_more = false;
+			return;
+		}
 
 		if( !loading_more ){
 			// When searching (non-empty query), keep selected items and HTML default options,
 			// but remove preloaded remote options so they don't bleed into search results.
 			// For empty query, use clearFilter (keeps default_values + items).
-			const activeFilter = self.lastValue !== ''
+			const activeFilter = query !== ''
 				? (_option: TomOption, value: string) => self.items.indexOf(value) >= 0 || html_values.indexOf(value) >= 0
 				: clearFilter;
 			self.clearOptions(activeFilter);
@@ -161,10 +186,8 @@ export default function(this:TomSelect) {
 		orig_loadCallback.call( self, options, optgroups);
 
 		// After the initial preload (empty query), snapshot default_values and option objects
-		// so they can be restored when the user clears their search. Only latch once a response for the
-		// empty query has actually been applied - a preload response that arrives after the user has
-		// already typed a search must not mark the (empty) defaults as loaded.
-		if( !loading_more && !default_values_loaded && self.lastValue === '' ){
+		// so they can be restored when the user clears their search.
+		if( !loading_more && !default_values_loaded && query === '' ){
 			default_values_loaded = true;
 			default_values = Object.keys(self.options);
 			default_pagination = pagination[''];
@@ -172,6 +195,32 @@ export default function(this:TomSelect) {
 		}
 
 		loading_more = false;
+	};
+
+	// bind the query (and whether this request is loading more results) into the callback of
+	// each load() request - loadCallback() alone cannot tell which request a response answers
+	self.hook('instead','load',(query:string)=>{
+		const was_loading_more	= loading_more;
+		const outer_callback	= self.loadCallback;
+		self.loadCallback = ( options:TomOption[], optgroups:TomOption[] ):void => {
+			loadCallbackForQuery( query, was_loading_more, options, optgroups );
+		};
+		try{
+			return orig_load.call( self, query );
+		}finally{
+			self.loadCallback = outer_callback;
+		}
+	});
+
+	// fallback for loadCallback() invoked directly rather than through a load() request
+	self.hook('instead','loadCallback',( options:TomOption[], optgroups:TomOption[])=>{
+		loadCallbackForQuery( self.lastValue, loading_more, options, optgroups );
+	});
+
+	// track that a preload was requested, so recovery from a discarded preload response
+	// doesn't issue empty-query requests when preloading was never enabled
+	self.hook('before','preload',()=>{
+		preload_requested = true;
 	});
 
 
@@ -218,10 +267,11 @@ export default function(this:TomSelect) {
 	// Restore preloaded options and pagination when clearing search
 	const restoreDefaults = ():void => {
 		if( !default_values_loaded ) {
-			// The initial preload never completed (e.g. the user typed a search before it returned), so
-			// there is nothing to restore - re-arm the preload so the first page is fetched again.
-			self.wrapper.classList.remove('preloaded');
-			if( self.isFocused ){
+			// There is nothing to restore. If a preload was requested but its response was
+			// discarded as stale (which removes the 'preloaded' class), request it again so the
+			// first page is fetched; if a preload is still in flight, or was never requested at
+			// all, do nothing - clearing the search must not issue requests of its own.
+			if( preload_requested && !self.wrapper.classList.contains('preloaded') && self.isFocused ){
 				self.preload();
 			}
 			return;

--- a/test/tests/plugins/virtual_scroll.js
+++ b/test/tests/plugins/virtual_scroll.js
@@ -210,6 +210,68 @@ describe('plugin: virtual_scroll', function() {
 	});
 
 
+	it_n('recovers when a stale preload response resolves after a search has already started',async ()=>{
+
+		var load_calls = 0;
+		var resolvePreload;
+
+		var test = setup_test('<input>',{
+			plugins:['virtual_scroll'],
+			labelField: 'value',
+			valueField: 'value',
+			searchField: 'value',
+			preload: 'focus',
+			loadThrottle: 1,
+			firstUrl: function(query){
+				return [query,0];
+			},
+			load: function(query, callback) {
+				load_calls++;
+				var url_params		= this.getUrl(query);
+				var self			= this;
+
+				// Hold back the preload's response so it can be resolved later, after the user
+				// has already started (and received results for) a search - simulating a slow
+				// network response for a request fired on focus, immediately followed by typing.
+				if( query === '' ){
+					resolvePreload = function(){
+						var data = DataProvider(url_params[0],url_params[1]);
+						self.setNextUrl(query,[query,url_params[1]+1]);
+						callback(data.data);
+					};
+					return;
+				}
+
+				var data = DataProvider(url_params[0],url_params[1]);
+				this.setNextUrl(query,[query,url_params[1]+1]);
+				callback(data.data);
+			}
+		});
+
+		// Focus triggers the preload, but its response is deliberately not resolved yet.
+		await asyncClick(test.instance.control);
+		assert.equal( load_calls, 1, 'preload should have been requested');
+
+		// Type a search before the preload resolves - this fetches and displays its own results.
+		await asyncType('a');
+		await waitFor(100);
+		assert.equal( load_calls, 2, 'search should have been requested');
+		assert.equal( Object.keys(test.instance.options).length, 20, 'should show only the search results');
+
+		// The stale preload response now lands, after the query has already moved on.
+		resolvePreload();
+		await waitFor(100);
+
+		// Clearing the search must not wipe the options, even though the preload never
+		// completed while the query was actually empty.
+		await asyncType('\b');
+		await waitFor(100);
+
+		assert.isAbove( Object.keys(test.instance.options).length, 0, 'options should not be wiped out after clearing search');
+		assert.equal( load_calls, 3, 'clearing the search should re-request the preload since it never completed');
+	});
+
+
 	it_n('virtual scroll works after clearing search',async ()=>{
 
 		var load_calls = 0;

--- a/test/tests/plugins/virtual_scroll.js
+++ b/test/tests/plugins/virtual_scroll.js
@@ -259,16 +259,124 @@ describe('plugin: virtual_scroll', function() {
 		assert.equal( Object.keys(test.instance.options).length, 20, 'should show only the search results');
 
 		// The stale preload response now lands, after the query has already moved on.
+		// It must be discarded without touching the options displayed for the active search.
 		resolvePreload();
 		await waitFor(100);
+		assert.deepEqual( Object.keys(test.instance.options), DataProvider('a',0).data.map(o=>o.value), 'search results should be unchanged after the stale preload response resolves');
 
-		// Clearing the search must not wipe the options, even though the preload never
-		// completed while the query was actually empty.
+		// Clearing the search re-requests the preload, since the discarded response never
+		// delivered it.
+		await asyncType('\b');
+		await waitFor(100);
+		assert.equal( load_calls, 3, 'clearing the search should re-request the preload since it never completed');
+
+		// The re-requested preload resolves; it must deliver the first page.
+		resolvePreload();
+		await waitFor(100);
+		assert.property( test.instance.options, '-0-0', 'recovery should reload the preload from the first page');
+		assert.deepEqual( Object.keys(test.instance.options), DataProvider('',0).data.map(o=>o.value), 'recovery should restore exactly the first page of preload results');
+	});
+
+
+	it_n('discards a search response that resolves after the input has been cleared',async ()=>{
+
+		var load_calls = 0;
+		var resolvers = {};
+
+		var test = setup_test('<input>',{
+			plugins:['virtual_scroll'],
+			labelField: 'value',
+			valueField: 'value',
+			searchField: 'value',
+			preload: 'focus',
+			loadThrottle: 1,
+			firstUrl: function(query){
+				return [query,0];
+			},
+			load: function(query, callback) {
+				load_calls++;
+				var url_params		= this.getUrl(query);
+				var self			= this;
+
+				// Hold back every response so they can be resolved out of order.
+				resolvers[query] = function(){
+					var data = DataProvider(url_params[0],url_params[1]);
+					self.setNextUrl(query,[query,url_params[1]+1]);
+					callback(data.data);
+				};
+			}
+		});
+
+		// Focus fires the preload; typing fires a search; both responses are still pending.
+		await asyncClick(test.instance.control);
+		await asyncType('a');
+		await waitFor(100);
+		assert.equal( load_calls, 2, 'preload and search should have been requested');
+
+		// Clear the input while both requests are in flight.
+		await asyncType('\b');
+		await waitFor(100);
+		assert.equal( load_calls, 2, 'clearing while the preload is still in flight should not issue another request');
+
+		// The search response resolves while the input is empty - it must not be applied,
+		// and it must not be captured as the preload defaults.
+		resolvers['a']();
+		await waitFor(100);
+		assert.equal( Object.keys(test.instance.options).filter(v => v.indexOf('a-') === 0).length, 0, 'stale search results should not be applied');
+
+		// The real preload response resolves and becomes the defaults.
+		resolvers['']();
+		await waitFor(100);
+		assert.deepEqual( Object.keys(test.instance.options), DataProvider('',0).data.map(o=>o.value), 'preload results should be applied once resolved');
+
+		// Search again and clear - the restored defaults must be the preload results,
+		// not the stale search results.
+		await asyncType('b');
+		await waitFor(100);
+		resolvers['b']();
+		await waitFor(100);
 		await asyncType('\b');
 		await waitFor(100);
 
-		assert.isAbove( Object.keys(test.instance.options).length, 0, 'options should not be wiped out after clearing search');
-		assert.equal( load_calls, 3, 'clearing the search should re-request the preload since it never completed');
+		assert.property( test.instance.options, '-0-0', 'clearing the search should restore the preloaded defaults');
+		assert.equal( Object.keys(test.instance.options).filter(v => v.indexOf('b-') === 0).length, 0, 'clearing the search should remove the search results');
+	});
+
+
+	it_n('does not issue an empty-query request when preload is disabled',async ()=>{
+
+		var loaded_queries = [];
+
+		var test = setup_test('<input>',{
+			plugins:['virtual_scroll'],
+			labelField: 'value',
+			valueField: 'value',
+			searchField: 'value',
+			loadThrottle: 1,
+			firstUrl: function(query){
+				return [query,0];
+			},
+			load: function(query, callback) {
+				loaded_queries.push(query);
+				var url_params		= this.getUrl(query);
+				var data			= DataProvider(url_params[0],url_params[1]);
+				this.setNextUrl(query,[query,url_params[1]+1]);
+				callback(data.data);
+			}
+		});
+
+		// Search, then clear the input while still focused.
+		await asyncClick(test.instance.control);
+		await asyncType('a');
+		await waitFor(100);
+		await asyncType('\b');
+		await waitFor(100);
+
+		// Close the dropdown as well - restoreDefaults() also runs on dropdown_close.
+		test.instance.close();
+		await waitFor(100);
+
+		assert.deepEqual( loaded_queries, ['a'], 'clearing the search or closing the dropdown should not request the empty query');
 	});
 
 


### PR DESCRIPTION
When `preload: 'focus'` is enabled, focusing the dropdown triggers a preload request for the empty query. If the user immediately types a search before the preload responds, a race condition can occur:

1. Focus fires `load('')` request (preload)
2. User types, fires `load('search')` request  
3. Preload response arrives after the search response
4. The snapshot latch (`default_values_loaded`) marks itself true despite capturing zero data
5. Clearing the search or closing the dropdown runs `restoreDefaults()` → `addOptions([])` → options wiped permanently
6. `preloaded` class prevents re-fetch, dropdown stays empty