### PR TITLE
fix: bootstrap5 theme: use Bootstrap's focus-box-shadow for validation-state focus ring

### DIFF
--- a/src/scss/tom-select.bootstrap5.scss
+++ b/src/scss/tom-select.bootstrap5.scss
@@ -73,7 +73,7 @@ $select-arrow-offset: calc(#{$select-padding-x} + 5px) !default;
 
 		&.focus .#{$select-ns}-control {
 			border-color: $color;
-			box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity);
+			box-shadow: map-get($state-map,'focus-box-shadow');
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #1082

## The problem

The focus outline ring does not appear when TomSelect field is in a validation state (has `is-invalid`/`is-valid` classes applied or is in a `was-validated` container). This is an accessibility fix that aims to return the outline on focus.

The issue appeared because TomSelect moved to Bootstrap `5.3` and there the `$color` started to resolve to a hex at runtime, but `rgba` cannot take a hex and instead requires comma separated RGB values so the whole declaration fails.

## What changed

From

```scss
box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity);
```

to

```scss
box-shadow: map-get($state-map,'focus-box-shadow');
```

This reads a key from Bootstrap's own Sass map that it uses itself for this use case. The value is expressed as a box shadow, hence it replaces the whole declaration value.

## Before/After

Here's before and after the change (done through the local html that points to the compiled bootstrap 5 theme for tomselect - `dist/css/tom-select.bootstrap5.css`).

| Before | After |
|---|---|
|<img width="1606" height="870" alt="127 0 0 1_5502_x-focus-ring html (1)" src="https://github.com/user-attachments/assets/3379dc05-dc90-4797-be63-9c562702dcd2" />|<img width="1606" height="870" alt="127 0 0 1_5502_x-focus-ring html (3)" src="https://github.com/user-attachments/assets/a8d887f4-0f8d-4336-af48-ff01619b2815" />|
|<img width="1606" height="870" alt="127 0 0 1_5502_x-focus-ring html (2)" src="https://github.com/user-attachments/assets/ee8b80c6-03ef-4c13-b33b-d66666684e85" />|<img width="1606" height="870" alt="127 0 0 1_5502_x-focus-ring html (4)" src="https://github.com/user-attachments/assets/82396466-9b6f-4a37-b996-86935f9e4b7e" />|
|<img width="442" height="85" alt="644710645-840a9a4f-9171-4fd3-954d-ea76f5a38c3b" src="https://github.com/user-attachments/assets/cf236179-bd9a-4129-8f17-481d8b0bee85" />|<img width="443" height="88" alt="Screenshot 2026-09-02 at 05 02 30" src="https://github.com/user-attachments/assets/63910f72-7612-4ff7-8c0a-74a183a9c039" />|


Success focus ring as well (AFTER):
<img width="600" alt="127 0 0 1_5502_x-focus-ring html (5)" src="https://github.com/user-attachments/assets/ce4213a1-b2b3-4ceb-aecd-02ad684c214b" />


## Tests

Ran on Node 22:
- `npm test` - all tests passed
- `npm run build` - successful
- `npm run stylelint` - successful
